### PR TITLE
feat(read): ✨ add read API façade

### DIFF
--- a/internal/read/api.go
+++ b/internal/read/api.go
@@ -1,0 +1,52 @@
+package read
+
+import (
+	"context"
+	"io"
+
+	"github.com/justapithecus/lode/lode"
+)
+
+// API defines the Lode read interface.
+//
+// This is a façade over storage and layout that performs no interpretation.
+// Per CONTRACT_READ_API.md: "Lode's read API exposes stored facts, not interpretations.
+// Planning and meaning belong to consumers."
+//
+// Discovery is manifest-driven. Segment visibility is determined by manifest presence.
+type API interface {
+	// ListDatasets returns all dataset IDs found in storage.
+	// Returns an empty slice (not error) if no datasets exist.
+	ListDatasets(ctx context.Context, opts DatasetListOptions) ([]lode.DatasetID, error)
+
+	// ListPartitions returns partition paths found across all committed segments.
+	// Per ambiguity resolution: partitions are discovered from manifests,
+	// aggregated across all committed segments (snapshots) in the dataset.
+	// Returns an empty slice (not error) if no partitions exist.
+	// Returns ErrNotFound if the dataset does not exist.
+	ListPartitions(ctx context.Context, dataset lode.DatasetID, opts PartitionListOptions) ([]PartitionRef, error)
+
+	// ListSegments returns committed segments (snapshots) within a dataset.
+	// Per CONTRACT_READ_API.md: manifest presence = commit signal.
+	// Segments without manifests are ignored.
+	// If partition is non-empty, filters to segments containing that partition.
+	// Returns an empty slice (not error) if no segments exist.
+	// Returns ErrNotFound if the dataset does not exist.
+	ListSegments(ctx context.Context, dataset lode.DatasetID, partition PartitionPath, opts SegmentListOptions) ([]SegmentRef, error)
+
+	// GetManifest loads the manifest for a specific segment.
+	// Returns ErrNotFound if the dataset or segment does not exist.
+	// Returns an error if the manifest is malformed.
+	GetManifest(ctx context.Context, dataset lode.DatasetID, seg SegmentRef) (*lode.Manifest, error)
+
+	// OpenObject returns a reader for a data object.
+	// The caller must close the reader when done.
+	// Returns ErrNotFound if the object does not exist.
+	OpenObject(ctx context.Context, obj ObjectRef) (io.ReadCloser, error)
+
+	// ObjectReaderAt returns a random-access reader for a data object.
+	// Supports repeated access without re-reading the full object.
+	// The caller must close the reader when done.
+	// Returns ErrNotFound if the object does not exist.
+	ObjectReaderAt(ctx context.Context, obj ObjectRef) (ReaderAt, error)
+}

--- a/internal/read/reader.go
+++ b/internal/read/reader.go
@@ -1,0 +1,247 @@
+package read
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/justapithecus/lode/lode"
+)
+
+// Layout constants matching internal/dataset layout.
+const (
+	datasetsDir     = "datasets"
+	snapshotsDir    = "snapshots"
+	manifestFile    = "manifest.json"
+	dataDir         = "data"
+)
+
+// ErrRangeReadNotSupported indicates that range reads are not supported.
+// This error is returned until ReadStorage adapters are implemented.
+var ErrRangeReadNotSupported = errors.New("range read not supported by this store")
+
+// Reader implements the read API using a storage backend.
+//
+// Reader is a façade that maps API calls to storage operations.
+// It performs no interpretation or planning.
+type Reader struct {
+	store lode.Store
+}
+
+// NewReader creates a Reader backed by the given store.
+func NewReader(store lode.Store) *Reader {
+	if store == nil {
+		panic("read: store is required")
+	}
+	return &Reader{store: store}
+}
+
+// ListDatasets returns all dataset IDs found in storage.
+func (r *Reader) ListDatasets(ctx context.Context, opts DatasetListOptions) ([]lode.DatasetID, error) {
+	// List all paths under datasets/
+	paths, err := r.store.List(ctx, datasetsDir+"/")
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract unique dataset IDs from manifest paths.
+	// Only datasets with at least one manifest are considered to exist.
+	seen := make(map[lode.DatasetID]bool)
+	var datasets []lode.DatasetID
+
+	for _, p := range paths {
+		if path.Base(p) != manifestFile {
+			continue
+		}
+
+		// Path format: datasets/<dataset_id>/snapshots/<snapshot_id>/manifest.json
+		parts := strings.Split(p, "/")
+		if len(parts) < 4 || parts[0] != datasetsDir {
+			continue
+		}
+
+		datasetID := lode.DatasetID(parts[1])
+		if seen[datasetID] {
+			continue
+		}
+		seen[datasetID] = true
+		datasets = append(datasets, datasetID)
+
+		if opts.Limit > 0 && len(datasets) >= opts.Limit {
+			break
+		}
+	}
+
+	return datasets, nil
+}
+
+// ListPartitions returns partition paths found across all committed segments.
+func (r *Reader) ListPartitions(ctx context.Context, dataset lode.DatasetID, opts PartitionListOptions) ([]PartitionRef, error) {
+	// First verify dataset exists by listing segments
+	segments, err := r.ListSegments(ctx, dataset, "", SegmentListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(segments) == 0 {
+		// Dataset exists but has no committed segments
+		return nil, nil
+	}
+
+	// Aggregate partitions from all manifests
+	seen := make(map[string]bool)
+	var partitions []PartitionRef
+
+	for _, seg := range segments {
+		manifest, err := r.GetManifest(ctx, dataset, seg)
+		if err != nil {
+			// Skip segments with unreadable manifests
+			continue
+		}
+
+		for _, f := range manifest.Files {
+			partPath := extractPartitionPath(f.Path)
+			if partPath == "" || seen[partPath] {
+				continue
+			}
+			seen[partPath] = true
+			partitions = append(partitions, PartitionRef{Path: partPath})
+
+			if opts.Limit > 0 && len(partitions) >= opts.Limit {
+				return partitions, nil
+			}
+		}
+	}
+
+	return partitions, nil
+}
+
+// extractPartitionPath extracts the partition path component from a file path.
+// File paths have format: datasets/<id>/snapshots/<id>/data/[partition/]filename
+// Returns empty string if no partition.
+func extractPartitionPath(filePath string) string {
+	parts := strings.Split(filePath, "/")
+
+	// Find the "data" component
+	dataIdx := -1
+	for i, p := range parts {
+		if p == dataDir {
+			dataIdx = i
+			break
+		}
+	}
+
+	if dataIdx < 0 || dataIdx >= len(parts)-1 {
+		return ""
+	}
+
+	// Everything between "data" and the filename is the partition path
+	partParts := parts[dataIdx+1 : len(parts)-1]
+	if len(partParts) == 0 {
+		return ""
+	}
+
+	return strings.Join(partParts, "/")
+}
+
+// ListSegments returns committed segments (snapshots) within a dataset.
+func (r *Reader) ListSegments(ctx context.Context, dataset lode.DatasetID, partition PartitionPath, opts SegmentListOptions) ([]SegmentRef, error) {
+	// List all paths under the dataset's snapshots directory
+	prefix := path.Join(datasetsDir, string(dataset), snapshotsDir) + "/"
+	paths, err := r.store.List(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract segment IDs from manifest paths
+	// Per CONTRACT_READ_API.md: manifest presence = commit signal
+	var segments []SegmentRef
+	seen := make(map[lode.SnapshotID]bool)
+
+	for _, p := range paths {
+		if path.Base(p) != manifestFile {
+			continue
+		}
+
+		// Path format: datasets/<dataset_id>/snapshots/<snapshot_id>/manifest.json
+		dir := path.Dir(p)
+		segmentID := lode.SnapshotID(path.Base(dir))
+
+		if seen[segmentID] {
+			continue
+		}
+
+		// If partition filter is specified, check if segment contains it
+		if partition != "" {
+			manifest, err := r.loadManifest(ctx, p)
+			if err != nil {
+				continue
+			}
+			if !segmentContainsPartition(manifest, string(partition)) {
+				continue
+			}
+		}
+
+		seen[segmentID] = true
+		segments = append(segments, SegmentRef{ID: segmentID})
+
+		if opts.Limit > 0 && len(segments) >= opts.Limit {
+			break
+		}
+	}
+
+	return segments, nil
+}
+
+// segmentContainsPartition checks if a manifest contains files in the given partition.
+func segmentContainsPartition(m *lode.Manifest, partition string) bool {
+	for _, f := range m.Files {
+		partPath := extractPartitionPath(f.Path)
+		if partPath == partition || strings.HasPrefix(partPath, partition+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// GetManifest loads the manifest for a specific segment.
+func (r *Reader) GetManifest(ctx context.Context, dataset lode.DatasetID, seg SegmentRef) (*lode.Manifest, error) {
+	manifestPath := path.Join(datasetsDir, string(dataset), snapshotsDir, string(seg.ID), manifestFile)
+	return r.loadManifest(ctx, manifestPath)
+}
+
+// loadManifest loads and parses a manifest from the given path.
+func (r *Reader) loadManifest(ctx context.Context, manifestPath string) (*lode.Manifest, error) {
+	rc, err := r.store.Get(ctx, manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	var manifest lode.Manifest
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// OpenObject returns a reader for a data object.
+func (r *Reader) OpenObject(ctx context.Context, obj ObjectRef) (io.ReadCloser, error) {
+	// Construct the full path from ObjectRef
+	objPath := path.Join(datasetsDir, string(obj.Dataset), snapshotsDir, string(obj.Segment.ID), obj.Path)
+	return r.store.Get(ctx, objPath)
+}
+
+// ObjectReaderAt returns a random-access reader for a data object.
+// Currently returns ErrRangeReadNotSupported as the basic Store interface
+// does not support range reads. This will be implemented in Task 4.
+func (r *Reader) ObjectReaderAt(ctx context.Context, obj ObjectRef) (ReaderAt, error) {
+	return nil, ErrRangeReadNotSupported
+}
+
+// Ensure Reader implements API
+var _ API = (*Reader)(nil)

--- a/internal/read/reader_test.go
+++ b/internal/read/reader_test.go
@@ -1,0 +1,390 @@
+package read
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/justapithecus/lode/internal/storage"
+	"github.com/justapithecus/lode/lode"
+)
+
+func TestNewReader_NilStore(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for nil store")
+		}
+	}()
+	NewReader(nil)
+}
+
+func TestListDatasets_Empty(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	datasets, err := reader.ListDatasets(context.Background(), DatasetListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(datasets) != 0 {
+		t.Errorf("expected empty list, got %d datasets", len(datasets))
+	}
+}
+
+func TestListDatasets_WithManifests(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifests for two datasets
+	writeTestManifest(t, ctx, store, "dataset-a", "snap-1")
+	writeTestManifest(t, ctx, store, "dataset-b", "snap-1")
+
+	reader := NewReader(store)
+	datasets, err := reader.ListDatasets(ctx, DatasetListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(datasets) != 2 {
+		t.Errorf("expected 2 datasets, got %d", len(datasets))
+	}
+}
+
+func TestListDatasets_Limit(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifests for three datasets
+	writeTestManifest(t, ctx, store, "dataset-a", "snap-1")
+	writeTestManifest(t, ctx, store, "dataset-b", "snap-1")
+	writeTestManifest(t, ctx, store, "dataset-c", "snap-1")
+
+	reader := NewReader(store)
+	datasets, err := reader.ListDatasets(ctx, DatasetListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(datasets) != 2 {
+		t.Errorf("expected 2 datasets with limit, got %d", len(datasets))
+	}
+}
+
+func TestListDatasets_IgnoresDataWithoutManifest(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write only a data file without manifest
+	err := store.Put(ctx, "datasets/orphan/snapshots/snap-1/data/file.json", bytes.NewReader([]byte("data")))
+	if err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	// Write a proper manifest for another dataset
+	writeTestManifest(t, ctx, store, "valid", "snap-1")
+
+	reader := NewReader(store)
+	datasets, err := reader.ListDatasets(ctx, DatasetListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only the dataset with manifest should be returned
+	if len(datasets) != 1 {
+		t.Errorf("expected 1 dataset, got %d", len(datasets))
+	}
+	if len(datasets) > 0 && datasets[0] != "valid" {
+		t.Errorf("expected dataset 'valid', got %q", datasets[0])
+	}
+}
+
+func TestListSegments_Empty(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	segments, err := reader.ListSegments(context.Background(), "nonexistent", "", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Empty list for nonexistent dataset (not error per contract)
+	if len(segments) != 0 {
+		t.Errorf("expected empty list, got %d segments", len(segments))
+	}
+}
+
+func TestListSegments_WithManifests(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	writeTestManifest(t, ctx, store, "mydata", "snap-1")
+	writeTestManifest(t, ctx, store, "mydata", "snap-2")
+
+	reader := NewReader(store)
+	segments, err := reader.ListSegments(ctx, "mydata", "", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(segments) != 2 {
+		t.Errorf("expected 2 segments, got %d", len(segments))
+	}
+}
+
+func TestListSegments_IgnoresSegmentsWithoutManifest(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write a proper manifest
+	writeTestManifest(t, ctx, store, "mydata", "snap-1")
+
+	// Write only a data file without manifest
+	err := store.Put(ctx, "datasets/mydata/snapshots/orphan/data/file.json", bytes.NewReader([]byte("data")))
+	if err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	reader := NewReader(store)
+	segments, err := reader.ListSegments(ctx, "mydata", "", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only segment with manifest should be returned
+	if len(segments) != 1 {
+		t.Errorf("expected 1 segment, got %d", len(segments))
+	}
+}
+
+func TestGetManifest_NotFound(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	_, err := reader.GetManifest(context.Background(), "missing", SegmentRef{ID: "snap-1"})
+	if !errors.Is(err, lode.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetManifest_Success(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	writeTestManifest(t, ctx, store, "mydata", "snap-1")
+
+	reader := NewReader(store)
+	manifest, err := reader.GetManifest(ctx, "mydata", SegmentRef{ID: "snap-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if manifest.DatasetID != "mydata" {
+		t.Errorf("expected dataset ID 'mydata', got %q", manifest.DatasetID)
+	}
+	if manifest.SnapshotID != "snap-1" {
+		t.Errorf("expected snapshot ID 'snap-1', got %q", manifest.SnapshotID)
+	}
+}
+
+func TestGetManifest_Malformed(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write invalid JSON
+	err := store.Put(ctx, "datasets/bad/snapshots/snap-1/manifest.json", bytes.NewReader([]byte("not json")))
+	if err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	reader := NewReader(store)
+	_, err = reader.GetManifest(ctx, "bad", SegmentRef{ID: "snap-1"})
+	if err == nil {
+		t.Error("expected error for malformed manifest")
+	}
+}
+
+func TestOpenObject_NotFound(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	_, err := reader.OpenObject(context.Background(), ObjectRef{
+		Dataset: "missing",
+		Segment: SegmentRef{ID: "snap-1"},
+		Path:    "data/file.json",
+	})
+	if !errors.Is(err, lode.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestOpenObject_Success(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write a data file
+	content := []byte(`{"test": "data"}`)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/data/file.json", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	reader := NewReader(store)
+	rc, err := reader.OpenObject(ctx, ObjectRef{
+		Dataset: "mydata",
+		Segment: SegmentRef{ID: "snap-1"},
+		Path:    "data/file.json",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer rc.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(rc); err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+
+	if buf.String() != string(content) {
+		t.Errorf("expected %q, got %q", string(content), buf.String())
+	}
+}
+
+func TestObjectReaderAt_NotSupported(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	_, err := reader.ObjectReaderAt(context.Background(), ObjectRef{
+		Dataset: "mydata",
+		Segment: SegmentRef{ID: "snap-1"},
+		Path:    "data/file.json",
+	})
+	if !errors.Is(err, ErrRangeReadNotSupported) {
+		t.Errorf("expected ErrRangeReadNotSupported, got %v", err)
+	}
+}
+
+func TestListPartitions_Empty(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	// No datasets exist
+	partitions, err := reader.ListPartitions(context.Background(), "nonexistent", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(partitions) != 0 {
+		t.Errorf("expected empty list, got %d partitions", len(partitions))
+	}
+}
+
+func TestListPartitions_WithPartitionedData(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifest with partitioned files
+	manifest := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-1/data/day=2024-01-01/file.json", SizeBytes: 100},
+			{Path: "datasets/mydata/snapshots/snap-1/data/day=2024-01-02/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive-dt",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+	partitions, err := reader.ListPartitions(ctx, "mydata", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(partitions) != 2 {
+		t.Errorf("expected 2 partitions, got %d", len(partitions))
+	}
+}
+
+func TestListPartitions_NoInference(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifest with unpartitioned files
+	manifest := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-1/data/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "noop",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+	partitions, err := reader.ListPartitions(ctx, "mydata", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No partitions should be inferred from unpartitioned data
+	if len(partitions) != 0 {
+		t.Errorf("expected 0 partitions (no inference), got %d", len(partitions))
+	}
+}
+
+// writeTestManifest writes a minimal valid manifest to storage.
+func writeTestManifest(t *testing.T, ctx context.Context, store lode.Store, dataset, snapshot string) {
+	t.Helper()
+
+	manifest := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     lode.DatasetID(dataset),
+		SnapshotID:    lode.SnapshotID(snapshot),
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files:         []lode.FileRef{},
+		RowCount:      0,
+		Codec:         "jsonl",
+		Compressor:    "noop",
+		Partitioner:   "noop",
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+
+	path := "datasets/" + dataset + "/snapshots/" + snapshot + "/manifest.json"
+	if err := store.Put(ctx, path, bytes.NewReader(data)); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+}

--- a/internal/read/storage.go
+++ b/internal/read/storage.go
@@ -1,0 +1,53 @@
+package read
+
+import (
+	"context"
+	"io"
+)
+
+// ReadStorage defines read-only storage operations required by the read API.
+//
+// This interface is internal and separate from lode.Store per CONTRACT_READ_API.md.
+// Adapters must support true range reads, not simulated full downloads.
+//
+// Consistency guarantees and mitigations must be documented by implementations.
+type ReadStorage interface {
+	// Stat returns metadata about an object.
+	// Returns ErrNotFound if the object does not exist.
+	Stat(ctx context.Context, key ObjectKey) (ObjectInfo, error)
+
+	// Open returns a reader for the entire object.
+	// The caller must close the reader when done.
+	// Returns ErrNotFound if the object does not exist.
+	Open(ctx context.Context, key ObjectKey) (io.ReadCloser, error)
+
+	// ReadRange reads a byte range from an object.
+	// Per CONTRACT_READ_API.md, this must be a true range read
+	// (e.g., HTTP Range on S3), not a simulated full download.
+	// Returns ErrNotFound if the object does not exist.
+	ReadRange(ctx context.Context, key ObjectKey, offset int64, length int64) ([]byte, error)
+
+	// ReaderAt returns a random-access reader for an object.
+	// Supports repeated access without re-reading the full object.
+	// The caller must close the reader when done.
+	// Returns ErrNotFound if the object does not exist.
+	ReaderAt(ctx context.Context, key ObjectKey) (ReaderAt, error)
+
+	// List returns objects matching the given prefix.
+	// Per CONTRACT_STORAGE.md, ordering is unspecified.
+	List(ctx context.Context, prefix ObjectKey, opts ListOptions) (ListPage, error)
+}
+
+// ReaderAt provides random access to an object.
+//
+// Per CONTRACT_READ_API.md, implementations should consider:
+// - Page size: 256KiB-1MiB
+// - Cache size: 32-256 pages
+// - Optional sequential prefetch
+type ReaderAt interface {
+	io.ReaderAt
+	io.Closer
+
+	// Size returns the total size of the object in bytes.
+	Size() int64
+}

--- a/internal/read/types.go
+++ b/internal/read/types.go
@@ -1,0 +1,85 @@
+// Package read provides internal read API types and implementation.
+//
+// Per AGENTS.md, these types are internal and not part of the public lode API.
+// The read API exposes stored facts, not interpretations.
+package read
+
+import "github.com/justapithecus/lode/lode"
+
+// ObjectKey identifies an object in storage.
+type ObjectKey string
+
+// ObjectInfo contains metadata about a stored object.
+type ObjectInfo struct {
+	// Key is the object's storage key.
+	Key ObjectKey
+
+	// SizeBytes is the object size in bytes.
+	SizeBytes int64
+}
+
+// ObjectRef references a data object within a segment.
+type ObjectRef struct {
+	// Dataset is the dataset containing this object.
+	Dataset lode.DatasetID
+
+	// Segment is the segment containing this object.
+	Segment SegmentRef
+
+	// Path is the object path relative to the segment.
+	Path string
+}
+
+// SegmentRef references an immutable segment (snapshot) within a dataset.
+// Per ambiguity resolution: Segment == Snapshot (1:1 mapping).
+type SegmentRef struct {
+	// ID is the segment/snapshot identifier.
+	ID lode.SnapshotID
+}
+
+// PartitionRef references a partition within a dataset.
+type PartitionRef struct {
+	// Path is the partition path (e.g., "day=2024-01-01/source=foo").
+	Path string
+}
+
+// PartitionPath is a partition path filter.
+// Empty string means all partitions.
+type PartitionPath string
+
+// ListOptions controls listing behavior.
+type ListOptions struct {
+	// Limit is the maximum number of results to return.
+	// Zero means no limit.
+	Limit int
+}
+
+// ListPage contains a page of listing results.
+type ListPage struct {
+	// Keys contains the matching object keys.
+	Keys []ObjectKey
+
+	// HasMore indicates if more results are available.
+	HasMore bool
+}
+
+// DatasetListOptions controls dataset listing.
+type DatasetListOptions struct {
+	// Limit is the maximum number of results to return.
+	// Zero means no limit.
+	Limit int
+}
+
+// PartitionListOptions controls partition listing.
+type PartitionListOptions struct {
+	// Limit is the maximum number of results to return.
+	// Zero means no limit.
+	Limit int
+}
+
+// SegmentListOptions controls segment listing.
+type SegmentListOptions struct {
+	// Limit is the maximum number of results to return.
+	// Zero means no limit.
+	Limit int
+}


### PR DESCRIPTION
  Implement internal read surface per CONTRACT_READ_API.md:
  - API interface: ListDatasets, ListPartitions, ListSegments, GetManifest, OpenObject, ObjectReaderAt
  - ReadStorage interface (separate from lode.Store)
  - Reader implementation mapping to existing Store
  - Segment == Snapshot (1:1 mapping per ambiguity resolution)

  Discovery is manifest-driven; no metadata inference.
  Range reads return ErrRangeReadNotSupported until Task 4.