### PR TITLE
feat(read): ✨ add manifest validation

### DIFF
--- a/internal/read/manifest.go
+++ b/internal/read/manifest.go
@@ -1,0 +1,119 @@
+package read
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/justapithecus/lode/lode"
+)
+
+// Manifest validation errors.
+var (
+	// ErrManifestInvalid indicates a manifest failed validation.
+	ErrManifestInvalid = errors.New("invalid manifest")
+)
+
+// ManifestValidationError provides details about manifest validation failures.
+type ManifestValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ManifestValidationError) Error() string {
+	return fmt.Sprintf("invalid manifest: %s: %s", e.Field, e.Message)
+}
+
+func (e *ManifestValidationError) Unwrap() error {
+	return ErrManifestInvalid
+}
+
+// ValidateManifest checks that a manifest contains all required fields
+// per CONTRACT_CORE.md and CONTRACT_READ_API.md.
+//
+// Required fields:
+//   - SchemaName: identifies the manifest schema
+//   - FormatVersion: identifies the schema version
+//   - DatasetID: identifies the dataset
+//   - SnapshotID: identifies the snapshot
+//   - CreatedAt: when the snapshot was committed (must not be zero)
+//   - Metadata: user-provided key-value pairs (must not be nil)
+//   - Files: list of data files (must not be nil, may be empty)
+//   - RowCount: total records (must be >= 0)
+//   - Codec: serialization format
+//   - Compressor: compression format
+//   - Partitioner: partitioning strategy
+//
+// Optional fields (not validated as required):
+//   - ParentSnapshotID: previous snapshot reference
+//   - MinTimestamp/MaxTimestamp: applicable only for timestamped records
+//   - File checksums: optional per CONTRACT_CORE.md
+func ValidateManifest(m *lode.Manifest) error {
+	if m == nil {
+		return &ManifestValidationError{Field: "manifest", Message: "is nil"}
+	}
+
+	// Schema identification
+	if m.SchemaName == "" {
+		return &ManifestValidationError{Field: "schema_name", Message: "is required"}
+	}
+	if m.FormatVersion == "" {
+		return &ManifestValidationError{Field: "format_version", Message: "is required"}
+	}
+
+	// Identity fields
+	if m.DatasetID == "" {
+		return &ManifestValidationError{Field: "dataset_id", Message: "is required"}
+	}
+	if m.SnapshotID == "" {
+		return &ManifestValidationError{Field: "snapshot_id", Message: "is required"}
+	}
+
+	// Timestamp
+	if m.CreatedAt.IsZero() {
+		return &ManifestValidationError{Field: "created_at", Message: "is required"}
+	}
+
+	// Metadata - per CONTRACT_CORE.md: nil metadata is invalid
+	if m.Metadata == nil {
+		return &ManifestValidationError{Field: "metadata", Message: "must not be nil (use empty map for no metadata)"}
+	}
+
+	// Files list - must not be nil (empty is valid for zero-record snapshots)
+	if m.Files == nil {
+		return &ManifestValidationError{Field: "files", Message: "must not be nil (use empty slice for no files)"}
+	}
+
+	// Row count - must be non-negative
+	if m.RowCount < 0 {
+		return &ManifestValidationError{Field: "row_count", Message: "must be non-negative"}
+	}
+
+	// Component fields - per CONTRACT_LAYOUT.md: must be explicit, never nil/empty
+	if m.Codec == "" {
+		return &ManifestValidationError{Field: "codec", Message: "is required"}
+	}
+	if m.Compressor == "" {
+		return &ManifestValidationError{Field: "compressor", Message: "is required"}
+	}
+	if m.Partitioner == "" {
+		return &ManifestValidationError{Field: "partitioner", Message: "is required"}
+	}
+
+	// Validate individual file references
+	for i, f := range m.Files {
+		if f.Path == "" {
+			return &ManifestValidationError{
+				Field:   fmt.Sprintf("files[%d].path", i),
+				Message: "is required",
+			}
+		}
+		if f.SizeBytes < 0 {
+			return &ManifestValidationError{
+				Field:   fmt.Sprintf("files[%d].size_bytes", i),
+				Message: "must be non-negative",
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/read/manifest_test.go
+++ b/internal/read/manifest_test.go
@@ -1,0 +1,405 @@
+package read
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/justapithecus/lode/internal/storage"
+	"github.com/justapithecus/lode/lode"
+)
+
+func TestValidateManifest_Valid(t *testing.T) {
+	m := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "test-dataset",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files:         []lode.FileRef{},
+		RowCount:      0,
+		Codec:         "jsonl",
+		Compressor:    "noop",
+		Partitioner:   "noop",
+	}
+
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest, got error: %v", err)
+	}
+}
+
+func TestValidateManifest_ValidWithFiles(t *testing.T) {
+	m := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "test-dataset",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{"key": "value"},
+		Files: []lode.FileRef{
+			{Path: "data/file1.json", SizeBytes: 100},
+			{Path: "data/file2.json", SizeBytes: 200, Checksum: "sha256:abc123"},
+		},
+		RowCount:    50,
+		Codec:       "jsonl",
+		Compressor:  "gzip",
+		Partitioner: "hive-dt",
+	}
+
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest, got error: %v", err)
+	}
+}
+
+func TestValidateManifest_Nil(t *testing.T) {
+	err := ValidateManifest(nil)
+	if err == nil {
+		t.Error("expected error for nil manifest")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got %v", err)
+	}
+}
+
+func TestValidateManifest_MissingSchemaName(t *testing.T) {
+	m := validManifest()
+	m.SchemaName = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "schema_name")
+}
+
+func TestValidateManifest_MissingFormatVersion(t *testing.T) {
+	m := validManifest()
+	m.FormatVersion = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "format_version")
+}
+
+func TestValidateManifest_MissingDatasetID(t *testing.T) {
+	m := validManifest()
+	m.DatasetID = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "dataset_id")
+}
+
+func TestValidateManifest_MissingSnapshotID(t *testing.T) {
+	m := validManifest()
+	m.SnapshotID = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "snapshot_id")
+}
+
+func TestValidateManifest_ZeroCreatedAt(t *testing.T) {
+	m := validManifest()
+	m.CreatedAt = time.Time{}
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "created_at")
+}
+
+func TestValidateManifest_NilMetadata(t *testing.T) {
+	m := validManifest()
+	m.Metadata = nil
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "metadata")
+}
+
+func TestValidateManifest_NilFiles(t *testing.T) {
+	m := validManifest()
+	m.Files = nil
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "files")
+}
+
+func TestValidateManifest_NegativeRowCount(t *testing.T) {
+	m := validManifest()
+	m.RowCount = -1
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "row_count")
+}
+
+func TestValidateManifest_MissingCodec(t *testing.T) {
+	m := validManifest()
+	m.Codec = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "codec")
+}
+
+func TestValidateManifest_MissingCompressor(t *testing.T) {
+	m := validManifest()
+	m.Compressor = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "compressor")
+}
+
+func TestValidateManifest_MissingPartitioner(t *testing.T) {
+	m := validManifest()
+	m.Partitioner = ""
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "partitioner")
+}
+
+func TestValidateManifest_FileWithEmptyPath(t *testing.T) {
+	m := validManifest()
+	m.Files = []lode.FileRef{
+		{Path: "", SizeBytes: 100},
+	}
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "files[0].path")
+}
+
+func TestValidateManifest_FileWithNegativeSize(t *testing.T) {
+	m := validManifest()
+	m.Files = []lode.FileRef{
+		{Path: "data/file.json", SizeBytes: -1},
+	}
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "files[0].size_bytes")
+}
+
+func TestValidateManifest_SecondFileInvalid(t *testing.T) {
+	m := validManifest()
+	m.Files = []lode.FileRef{
+		{Path: "data/file1.json", SizeBytes: 100},
+		{Path: "", SizeBytes: 200}, // invalid
+	}
+
+	err := ValidateManifest(m)
+	assertValidationError(t, err, "files[1].path")
+}
+
+// -----------------------------------------------------------------------------
+// Integration tests: GetManifest with validation
+// -----------------------------------------------------------------------------
+
+func TestGetManifest_ValidationError_MissingSchemaName(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifest missing schema_name
+	manifest := map[string]any{
+		"format_version": "1.0.0",
+		"dataset_id":     "mydata",
+		"snapshot_id":    "snap-1",
+		"created_at":     time.Now().UTC(),
+		"metadata":       map[string]any{},
+		"files":          []any{},
+		"row_count":      0,
+		"codec":          "jsonl",
+		"compressor":     "noop",
+		"partitioner":    "noop",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+	_, err = reader.GetManifest(ctx, "mydata", SegmentRef{ID: "snap-1"})
+	if err == nil {
+		t.Error("expected validation error")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got %v", err)
+	}
+}
+
+func TestGetManifest_ValidationError_NilMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifest with null metadata (nil when decoded)
+	manifest := map[string]any{
+		"schema_name":    "lode-manifest",
+		"format_version": "1.0.0",
+		"dataset_id":     "mydata",
+		"snapshot_id":    "snap-1",
+		"created_at":     time.Now().UTC(),
+		"metadata":       nil, // explicitly null
+		"files":          []any{},
+		"row_count":      0,
+		"codec":          "jsonl",
+		"compressor":     "noop",
+		"partitioner":    "noop",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+	_, err = reader.GetManifest(ctx, "mydata", SegmentRef{ID: "snap-1"})
+	if err == nil {
+		t.Error("expected validation error for nil metadata")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got %v", err)
+	}
+}
+
+func TestGetManifest_ValidationError_MissingCodec(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifest missing codec
+	manifest := map[string]any{
+		"schema_name":    "lode-manifest",
+		"format_version": "1.0.0",
+		"dataset_id":     "mydata",
+		"snapshot_id":    "snap-1",
+		"created_at":     time.Now().UTC(),
+		"metadata":       map[string]any{},
+		"files":          []any{},
+		"row_count":      0,
+		// codec missing
+		"compressor":  "noop",
+		"partitioner": "noop",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+	_, err = reader.GetManifest(ctx, "mydata", SegmentRef{ID: "snap-1"})
+	if err == nil {
+		t.Error("expected validation error for missing codec")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got %v", err)
+	}
+}
+
+func TestGetManifest_DecodeError_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write invalid JSON
+	err := store.Put(ctx, "datasets/bad/snapshots/snap-1/manifest.json", bytes.NewReader([]byte("not json")))
+	if err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	reader := NewReader(store)
+	_, err = reader.GetManifest(ctx, "bad", SegmentRef{ID: "snap-1"})
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+	// Should not be ErrManifestInvalid - it's a decode error
+	if errors.Is(err, ErrManifestInvalid) {
+		t.Error("decode error should not be ErrManifestInvalid")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Optional fields tests
+// -----------------------------------------------------------------------------
+
+func TestValidateManifest_OptionalParentSnapshotID(t *testing.T) {
+	m := validManifest()
+	m.ParentSnapshotID = "" // optional, empty is valid
+
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest (empty parent is optional), got error: %v", err)
+	}
+
+	m.ParentSnapshotID = "snap-0" // also valid when set
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest (parent set), got error: %v", err)
+	}
+}
+
+func TestValidateManifest_OptionalTimestamps(t *testing.T) {
+	m := validManifest()
+	m.MinTimestamp = nil
+	m.MaxTimestamp = nil
+
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest (nil timestamps are optional), got error: %v", err)
+	}
+
+	now := time.Now().UTC()
+	m.MinTimestamp = &now
+	m.MaxTimestamp = &now
+
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest (timestamps set), got error: %v", err)
+	}
+}
+
+func TestValidateManifest_OptionalChecksum(t *testing.T) {
+	m := validManifest()
+	m.Files = []lode.FileRef{
+		{Path: "data/file.json", SizeBytes: 100, Checksum: ""}, // optional
+	}
+
+	if err := ValidateManifest(m); err != nil {
+		t.Errorf("expected valid manifest (checksum optional), got error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Helper functions
+// -----------------------------------------------------------------------------
+
+func validManifest() *lode.Manifest {
+	return &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "test-dataset",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files:         []lode.FileRef{},
+		RowCount:      0,
+		Codec:         "jsonl",
+		Compressor:    "noop",
+		Partitioner:   "noop",
+	}
+}
+
+func assertValidationError(t *testing.T, err error, expectedField string) {
+	t.Helper()
+
+	if err == nil {
+		t.Errorf("expected validation error for field %q, got nil", expectedField)
+		return
+	}
+
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got %v", err)
+		return
+	}
+
+	var valErr *ManifestValidationError
+	if !errors.As(err, &valErr) {
+		t.Errorf("expected ManifestValidationError, got %T", err)
+		return
+	}
+
+	if valErr.Field != expectedField {
+		t.Errorf("expected field %q, got %q", expectedField, valErr.Field)
+	}
+}

--- a/internal/read/reader_test.go
+++ b/internal/read/reader_test.go
@@ -360,6 +360,456 @@ func TestListPartitions_NoInference(t *testing.T) {
 	}
 }
 
+// -----------------------------------------------------------------------------
+// Order-independence tests (per CONTRACT_STORAGE.md: ordering is unspecified)
+// -----------------------------------------------------------------------------
+
+func TestListDatasets_OrderIndependent(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifests for multiple datasets
+	expected := []lode.DatasetID{"alpha", "beta", "gamma"}
+	for _, id := range expected {
+		writeTestManifest(t, ctx, store, string(id), "snap-1")
+	}
+
+	reader := NewReader(store)
+	datasets, err := reader.ListDatasets(ctx, DatasetListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify all expected datasets are present (order-independent)
+	if !datasetIDsEqual(datasets, expected) {
+		t.Errorf("expected datasets %v, got %v", expected, datasets)
+	}
+}
+
+func TestListSegments_OrderIndependent(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write multiple segments
+	expected := []lode.SnapshotID{"snap-a", "snap-b", "snap-c"}
+	for _, id := range expected {
+		writeTestManifest(t, ctx, store, "mydata", string(id))
+	}
+
+	reader := NewReader(store)
+	segments, err := reader.ListSegments(ctx, "mydata", "", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify all expected segments are present (order-independent)
+	got := make([]lode.SnapshotID, len(segments))
+	for i, s := range segments {
+		got[i] = s.ID
+	}
+	if !snapshotIDsEqual(got, expected) {
+		t.Errorf("expected segments %v, got %v", expected, got)
+	}
+}
+
+func TestListPartitions_OrderIndependent(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write manifest with multiple partitions
+	manifest := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-1/data/region=us/file.json", SizeBytes: 100},
+			{Path: "datasets/mydata/snapshots/snap-1/data/region=eu/file.json", SizeBytes: 100},
+			{Path: "datasets/mydata/snapshots/snap-1/data/region=ap/file.json", SizeBytes: 100},
+		},
+		RowCount:    30,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+	partitions, err := reader.ListPartitions(ctx, "mydata", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify all expected partitions are present (order-independent)
+	expected := []string{"region=us", "region=eu", "region=ap"}
+	got := make([]string, len(partitions))
+	for i, p := range partitions {
+		got[i] = p.Path
+	}
+	if !stringsEqual(got, expected) {
+		t.Errorf("expected partitions %v, got %v", expected, got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Empty dataset edge cases (Task 2 requirements)
+// -----------------------------------------------------------------------------
+
+func TestListSegments_EmptyDataset_ReturnsEmptyList(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Create a dataset directory structure without any manifests
+	// This simulates a dataset that exists but has no committed segments
+	err := store.Put(ctx, "datasets/empty-dataset/readme.txt", bytes.NewReader([]byte("placeholder")))
+	if err != nil {
+		t.Fatalf("failed to write placeholder: %v", err)
+	}
+
+	reader := NewReader(store)
+	segments, err := reader.ListSegments(ctx, "empty-dataset", "", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("expected no error for empty dataset, got %v", err)
+	}
+
+	if len(segments) != 0 {
+		t.Errorf("expected empty list, got %d segments", len(segments))
+	}
+}
+
+func TestListPartitions_DatasetWithNoSegments_ReturnsEmptyList(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	// Dataset doesn't exist at all
+	partitions, err := reader.ListPartitions(context.Background(), "nonexistent", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(partitions) != 0 {
+		t.Errorf("expected empty list, got %d partitions", len(partitions))
+	}
+}
+
+func TestListSegments_WithPartitionFilter_EmptyDataset(t *testing.T) {
+	store := storage.NewMemory()
+	reader := NewReader(store)
+
+	// Query with partition filter on nonexistent dataset
+	segments, err := reader.ListSegments(context.Background(), "nonexistent", "day=2024-01-01", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(segments) != 0 {
+		t.Errorf("expected empty list, got %d segments", len(segments))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Partition filter tests (Task 2 requirements)
+// -----------------------------------------------------------------------------
+
+func TestListSegments_WithPartitionFilter(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Segment 1: has partition day=2024-01-01
+	manifest1 := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-1/data/day=2024-01-01/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive-dt",
+	}
+
+	// Segment 2: has partition day=2024-01-02
+	manifest2 := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-2",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-2/data/day=2024-01-02/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive-dt",
+	}
+
+	// Segment 3: has both partitions
+	manifest3 := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-3",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-3/data/day=2024-01-01/file.json", SizeBytes: 100},
+			{Path: "datasets/mydata/snapshots/snap-3/data/day=2024-01-02/file.json", SizeBytes: 100},
+		},
+		RowCount:    20,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive-dt",
+	}
+
+	for _, m := range []*lode.Manifest{manifest1, manifest2, manifest3} {
+		data, _ := json.Marshal(m)
+		path := "datasets/mydata/snapshots/" + string(m.SnapshotID) + "/manifest.json"
+		if err := store.Put(ctx, path, bytes.NewReader(data)); err != nil {
+			t.Fatalf("failed to write manifest: %v", err)
+		}
+	}
+
+	reader := NewReader(store)
+
+	// Filter by day=2024-01-01 should return snap-1 and snap-3
+	segments, err := reader.ListSegments(ctx, "mydata", "day=2024-01-01", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(segments) != 2 {
+		t.Errorf("expected 2 segments with day=2024-01-01, got %d", len(segments))
+	}
+
+	got := make([]lode.SnapshotID, len(segments))
+	for i, s := range segments {
+		got[i] = s.ID
+	}
+	expected := []lode.SnapshotID{"snap-1", "snap-3"}
+	if !snapshotIDsEqual(got, expected) {
+		t.Errorf("expected segments %v, got %v", expected, got)
+	}
+}
+
+func TestListSegments_WithPartitionFilter_NoMatch(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Write a manifest with a different partition
+	manifest := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-1/data/day=2024-01-01/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive-dt",
+	}
+
+	data, _ := json.Marshal(manifest)
+	err := store.Put(ctx, "datasets/mydata/snapshots/snap-1/manifest.json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	reader := NewReader(store)
+
+	// Filter by non-existent partition
+	segments, err := reader.ListSegments(ctx, "mydata", "day=2024-12-31", SegmentListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(segments) != 0 {
+		t.Errorf("expected 0 segments, got %d", len(segments))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Aggregated partitions across segments
+// -----------------------------------------------------------------------------
+
+func TestListPartitions_AggregatesAcrossSegments(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Segment 1: partition A
+	manifest1 := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-1/data/region=us/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive",
+	}
+
+	// Segment 2: partition B
+	manifest2 := &lode.Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "mydata",
+		SnapshotID:    "snap-2",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      lode.Metadata{},
+		Files: []lode.FileRef{
+			{Path: "datasets/mydata/snapshots/snap-2/data/region=eu/file.json", SizeBytes: 100},
+		},
+		RowCount:    10,
+		Codec:       "jsonl",
+		Compressor:  "noop",
+		Partitioner: "hive",
+	}
+
+	for _, m := range []*lode.Manifest{manifest1, manifest2} {
+		data, _ := json.Marshal(m)
+		path := "datasets/mydata/snapshots/" + string(m.SnapshotID) + "/manifest.json"
+		if err := store.Put(ctx, path, bytes.NewReader(data)); err != nil {
+			t.Fatalf("failed to write manifest: %v", err)
+		}
+	}
+
+	reader := NewReader(store)
+	partitions, err := reader.ListPartitions(ctx, "mydata", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should aggregate partitions from both segments
+	if len(partitions) != 2 {
+		t.Errorf("expected 2 partitions, got %d", len(partitions))
+	}
+
+	got := make([]string, len(partitions))
+	for i, p := range partitions {
+		got[i] = p.Path
+	}
+	expected := []string{"region=us", "region=eu"}
+	if !stringsEqual(got, expected) {
+		t.Errorf("expected partitions %v, got %v", expected, got)
+	}
+}
+
+func TestListPartitions_DeduplicatesAcrossSegments(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemory()
+
+	// Both segments have the same partition
+	for _, snapID := range []string{"snap-1", "snap-2"} {
+		manifest := &lode.Manifest{
+			SchemaName:    "lode-manifest",
+			FormatVersion: "1.0.0",
+			DatasetID:     "mydata",
+			SnapshotID:    lode.SnapshotID(snapID),
+			CreatedAt:     time.Now().UTC(),
+			Metadata:      lode.Metadata{},
+			Files: []lode.FileRef{
+				{Path: "datasets/mydata/snapshots/" + snapID + "/data/region=us/file.json", SizeBytes: 100},
+			},
+			RowCount:    10,
+			Codec:       "jsonl",
+			Compressor:  "noop",
+			Partitioner: "hive",
+		}
+		data, _ := json.Marshal(manifest)
+		path := "datasets/mydata/snapshots/" + snapID + "/manifest.json"
+		if err := store.Put(ctx, path, bytes.NewReader(data)); err != nil {
+			t.Fatalf("failed to write manifest: %v", err)
+		}
+	}
+
+	reader := NewReader(store)
+	partitions, err := reader.ListPartitions(ctx, "mydata", PartitionListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should deduplicate - only one "region=us" partition
+	if len(partitions) != 1 {
+		t.Errorf("expected 1 partition (deduplicated), got %d", len(partitions))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Helper functions for order-independent comparison
+// -----------------------------------------------------------------------------
+
+func datasetIDsEqual(a, b []lode.DatasetID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[lode.DatasetID]int)
+	for _, id := range a {
+		m[id]++
+	}
+	for _, id := range b {
+		m[id]--
+		if m[id] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func snapshotIDsEqual(a, b []lode.SnapshotID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[lode.SnapshotID]int)
+	for _, id := range a {
+		m[id]++
+	}
+	for _, id := range b {
+		m[id]--
+		if m[id] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[string]int)
+	for _, s := range a {
+		m[s]++
+	}
+	for _, s := range b {
+		m[s]--
+		if m[s] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // writeTestManifest writes a minimal valid manifest to storage.
 func writeTestManifest(t *testing.T, ctx context.Context, store lode.Store, dataset, snapshot string) {
 	t.Helper()


### PR DESCRIPTION
  Implement manifest field validation per CONTRACT_CORE.md:
  - ValidateManifest checks all required fields
  - ManifestValidationError provides field-level details
  - Integrated into loadManifest (single object fetch)

  Required: schema, version, dataset/snapshot IDs, created_at,
  metadata (non-nil), files (non-nil), row_count, codec,
  compressor, partitioner, file paths and sizes.