### PR TITLE
feat(read): ✨ add iterator lifecycle compliance

### DIFF
--- a/internal/read/iterator.go
+++ b/internal/read/iterator.go
@@ -1,0 +1,213 @@
+package read
+
+import (
+	"github.com/justapithecus/lode/lode"
+)
+
+// ObjectIterator provides sequential access to objects.
+//
+// Per CONTRACT_ITERATION.md:
+//   - Ordering is unspecified
+//   - Pagination is unspecified
+//   - Next() MUST return false after exhaustion or after Close() is called
+//   - Close() MUST be idempotent
+//   - Err() MAY be called after exhaustion or close
+//   - Implementations MUST release resources on Close() or exhaustion
+//
+// Prohibited behaviors:
+//   - Implicit ordering guarantees
+//   - Hidden buffering that changes visibility semantics
+type ObjectIterator interface {
+	// Next advances to the next object.
+	// Returns true if there is a next object, false if exhausted or closed.
+	// Must return false after Close() is called.
+	Next() bool
+
+	// Ref returns the current object reference.
+	// Only valid after Next() returns true.
+	Ref() ObjectRef
+
+	// Err returns any error encountered during iteration.
+	// May be called after exhaustion or close.
+	Err() error
+
+	// Close releases resources held by the iterator.
+	// Must be idempotent (safe to call multiple times).
+	Close() error
+}
+
+// SegmentFileIterator iterates over files in a segment's manifest.
+//
+// This iterator does not guarantee any ordering of files.
+// It does not perform hidden buffering that changes visibility.
+type SegmentFileIterator struct {
+	dataset lode.DatasetID
+	segment SegmentRef
+	files   []lode.FileRef
+	index   int
+	current ObjectRef
+	err     error
+	closed  bool
+}
+
+// NewSegmentFileIterator creates an iterator over the files in a manifest.
+// The iterator takes ownership of the files slice and will not modify it.
+func NewSegmentFileIterator(dataset lode.DatasetID, segment SegmentRef, files []lode.FileRef) *SegmentFileIterator {
+	return &SegmentFileIterator{
+		dataset: dataset,
+		segment: segment,
+		files:   files,
+		index:   -1, // Start before first element
+	}
+}
+
+// Next advances to the next file.
+// Returns false if exhausted or if Close() has been called.
+func (it *SegmentFileIterator) Next() bool {
+	// Per contract: Next() must return false after Close()
+	if it.closed {
+		return false
+	}
+
+	it.index++
+
+	// Check for exhaustion
+	if it.index >= len(it.files) {
+		return false
+	}
+
+	// Build current ObjectRef
+	it.current = ObjectRef{
+		Dataset: it.dataset,
+		Segment: it.segment,
+		Path:    it.files[it.index].Path,
+	}
+
+	return true
+}
+
+// Ref returns the current object reference.
+// Only valid after Next() returns true.
+func (it *SegmentFileIterator) Ref() ObjectRef {
+	return it.current
+}
+
+// Err returns any error encountered during iteration.
+// For this simple iterator, errors are not expected during iteration,
+// but the method is provided per the contract.
+func (it *SegmentFileIterator) Err() error {
+	return it.err
+}
+
+// Close releases resources and marks the iterator as closed.
+// Idempotent: safe to call multiple times.
+func (it *SegmentFileIterator) Close() error {
+	it.closed = true
+	// Release reference to files slice to allow GC
+	it.files = nil
+	return nil
+}
+
+// Ensure SegmentFileIterator implements ObjectIterator
+var _ ObjectIterator = (*SegmentFileIterator)(nil)
+
+// ListingIterator iterates over objects from a storage listing.
+//
+// This iterator wraps a slice of ObjectKeys from a List operation.
+// It does not guarantee any ordering.
+type ListingIterator struct {
+	dataset lode.DatasetID
+	segment SegmentRef
+	keys    []ObjectKey
+	index   int
+	current ObjectRef
+	err     error
+	closed  bool
+}
+
+// NewListingIterator creates an iterator over listing results.
+func NewListingIterator(dataset lode.DatasetID, segment SegmentRef, keys []ObjectKey) *ListingIterator {
+	return &ListingIterator{
+		dataset: dataset,
+		segment: segment,
+		keys:    keys,
+		index:   -1,
+	}
+}
+
+// Next advances to the next object.
+func (it *ListingIterator) Next() bool {
+	if it.closed {
+		return false
+	}
+
+	it.index++
+
+	if it.index >= len(it.keys) {
+		return false
+	}
+
+	it.current = ObjectRef{
+		Dataset: it.dataset,
+		Segment: it.segment,
+		Path:    string(it.keys[it.index]),
+	}
+
+	return true
+}
+
+// Ref returns the current object reference.
+func (it *ListingIterator) Ref() ObjectRef {
+	return it.current
+}
+
+// Err returns any error encountered during iteration.
+func (it *ListingIterator) Err() error {
+	return it.err
+}
+
+// Close releases resources and marks the iterator as closed.
+// Idempotent.
+func (it *ListingIterator) Close() error {
+	it.closed = true
+	it.keys = nil
+	return nil
+}
+
+// Ensure ListingIterator implements ObjectIterator
+var _ ObjectIterator = (*ListingIterator)(nil)
+
+// EmptyIterator is an iterator that yields no objects.
+// Useful for empty results without allocating state.
+type EmptyIterator struct {
+	closed bool
+}
+
+// NewEmptyIterator creates an iterator that yields no objects.
+func NewEmptyIterator() *EmptyIterator {
+	return &EmptyIterator{}
+}
+
+// Next always returns false.
+func (it *EmptyIterator) Next() bool {
+	return false
+}
+
+// Ref returns a zero ObjectRef.
+func (it *EmptyIterator) Ref() ObjectRef {
+	return ObjectRef{}
+}
+
+// Err returns nil.
+func (it *EmptyIterator) Err() error {
+	return nil
+}
+
+// Close marks the iterator as closed. Idempotent.
+func (it *EmptyIterator) Close() error {
+	it.closed = true
+	return nil
+}
+
+// Ensure EmptyIterator implements ObjectIterator
+var _ ObjectIterator = (*EmptyIterator)(nil)

--- a/internal/read/iterator_test.go
+++ b/internal/read/iterator_test.go
@@ -1,0 +1,327 @@
+package read
+
+import (
+	"testing"
+
+	"github.com/justapithecus/lode/lode"
+)
+
+// -----------------------------------------------------------------------------
+// SegmentFileIterator tests
+// -----------------------------------------------------------------------------
+
+func TestSegmentFileIterator_Basic(t *testing.T) {
+	files := []lode.FileRef{
+		{Path: "data/file1.json", SizeBytes: 100},
+		{Path: "data/file2.json", SizeBytes: 200},
+		{Path: "data/file3.json", SizeBytes: 300},
+	}
+
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+	defer it.Close()
+
+	var refs []ObjectRef
+	for it.Next() {
+		refs = append(refs, it.Ref())
+	}
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+
+	if len(refs) != 3 {
+		t.Errorf("expected 3 refs, got %d", len(refs))
+	}
+}
+
+func TestSegmentFileIterator_Empty(t *testing.T) {
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, []lode.FileRef{})
+	defer it.Close()
+
+	if it.Next() {
+		t.Error("Next() should return false for empty iterator")
+	}
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+}
+
+func TestSegmentFileIterator_CloseIdempotent(t *testing.T) {
+	files := []lode.FileRef{{Path: "data/file.json", SizeBytes: 100}}
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+
+	// Close multiple times - should not panic or error
+	for i := 0; i < 3; i++ {
+		err := it.Close()
+		if err != nil {
+			t.Errorf("Close() iteration %d returned error: %v", i, err)
+		}
+	}
+}
+
+func TestSegmentFileIterator_NextAfterClose(t *testing.T) {
+	files := []lode.FileRef{
+		{Path: "data/file1.json", SizeBytes: 100},
+		{Path: "data/file2.json", SizeBytes: 200},
+	}
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+
+	// Advance once
+	if !it.Next() {
+		t.Fatal("expected Next() to return true")
+	}
+
+	// Close
+	_ = it.Close()
+
+	// Next() must return false after Close()
+	if it.Next() {
+		t.Error("Next() must return false after Close()")
+	}
+}
+
+func TestSegmentFileIterator_NextAfterExhaustion(t *testing.T) {
+	files := []lode.FileRef{{Path: "data/file.json", SizeBytes: 100}}
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+	defer it.Close()
+
+	// Exhaust the iterator
+	for it.Next() {
+	}
+
+	// Additional Next() calls must return false
+	for i := 0; i < 3; i++ {
+		if it.Next() {
+			t.Errorf("Next() iteration %d should return false after exhaustion", i)
+		}
+	}
+}
+
+func TestSegmentFileIterator_ErrAfterExhaustion(t *testing.T) {
+	files := []lode.FileRef{{Path: "data/file.json", SizeBytes: 100}}
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+	defer it.Close()
+
+	// Exhaust
+	for it.Next() {
+	}
+
+	// Err() must be callable after exhaustion
+	if it.Err() != nil {
+		t.Errorf("unexpected error after exhaustion: %v", it.Err())
+	}
+}
+
+func TestSegmentFileIterator_ErrAfterClose(t *testing.T) {
+	files := []lode.FileRef{{Path: "data/file.json", SizeBytes: 100}}
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+
+	_ = it.Close()
+
+	// Err() must be callable after Close()
+	if it.Err() != nil {
+		t.Errorf("unexpected error after close: %v", it.Err())
+	}
+}
+
+func TestSegmentFileIterator_RefContents(t *testing.T) {
+	files := []lode.FileRef{
+		{Path: "data/part=a/file.json", SizeBytes: 100},
+	}
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+	defer it.Close()
+
+	if !it.Next() {
+		t.Fatal("expected Next() to return true")
+	}
+
+	ref := it.Ref()
+	if ref.Dataset != "mydata" {
+		t.Errorf("Dataset = %q, want %q", ref.Dataset, "mydata")
+	}
+	if ref.Segment.ID != "snap-1" {
+		t.Errorf("Segment.ID = %q, want %q", ref.Segment.ID, "snap-1")
+	}
+	if ref.Path != "data/part=a/file.json" {
+		t.Errorf("Path = %q, want %q", ref.Path, "data/part=a/file.json")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ListingIterator tests
+// -----------------------------------------------------------------------------
+
+func TestListingIterator_Basic(t *testing.T) {
+	keys := []ObjectKey{"obj1", "obj2", "obj3"}
+	it := NewListingIterator("mydata", SegmentRef{ID: "snap-1"}, keys)
+	defer it.Close()
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+
+	if count != 3 {
+		t.Errorf("expected 3 iterations, got %d", count)
+	}
+}
+
+func TestListingIterator_CloseIdempotent(t *testing.T) {
+	keys := []ObjectKey{"obj1"}
+	it := NewListingIterator("mydata", SegmentRef{ID: "snap-1"}, keys)
+
+	for i := 0; i < 3; i++ {
+		err := it.Close()
+		if err != nil {
+			t.Errorf("Close() iteration %d returned error: %v", i, err)
+		}
+	}
+}
+
+func TestListingIterator_NextAfterClose(t *testing.T) {
+	keys := []ObjectKey{"obj1", "obj2"}
+	it := NewListingIterator("mydata", SegmentRef{ID: "snap-1"}, keys)
+
+	if !it.Next() {
+		t.Fatal("expected Next() to return true")
+	}
+
+	_ = it.Close()
+
+	if it.Next() {
+		t.Error("Next() must return false after Close()")
+	}
+}
+
+func TestListingIterator_NextAfterExhaustion(t *testing.T) {
+	keys := []ObjectKey{"obj1"}
+	it := NewListingIterator("mydata", SegmentRef{ID: "snap-1"}, keys)
+	defer it.Close()
+
+	for it.Next() {
+	}
+
+	for i := 0; i < 3; i++ {
+		if it.Next() {
+			t.Errorf("Next() iteration %d should return false after exhaustion", i)
+		}
+	}
+}
+
+func TestListingIterator_ErrAfterExhaustion(t *testing.T) {
+	keys := []ObjectKey{"obj1"}
+	it := NewListingIterator("mydata", SegmentRef{ID: "snap-1"}, keys)
+	defer it.Close()
+
+	for it.Next() {
+	}
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+}
+
+func TestListingIterator_ErrAfterClose(t *testing.T) {
+	keys := []ObjectKey{"obj1"}
+	it := NewListingIterator("mydata", SegmentRef{ID: "snap-1"}, keys)
+
+	_ = it.Close()
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// EmptyIterator tests
+// -----------------------------------------------------------------------------
+
+func TestEmptyIterator_Basic(t *testing.T) {
+	it := NewEmptyIterator()
+	defer it.Close()
+
+	if it.Next() {
+		t.Error("EmptyIterator.Next() should always return false")
+	}
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+}
+
+func TestEmptyIterator_CloseIdempotent(t *testing.T) {
+	it := NewEmptyIterator()
+
+	for i := 0; i < 3; i++ {
+		err := it.Close()
+		if err != nil {
+			t.Errorf("Close() iteration %d returned error: %v", i, err)
+		}
+	}
+}
+
+func TestEmptyIterator_NextAfterClose(t *testing.T) {
+	it := NewEmptyIterator()
+
+	_ = it.Close()
+
+	if it.Next() {
+		t.Error("Next() must return false after Close()")
+	}
+}
+
+func TestEmptyIterator_ErrAfterClose(t *testing.T) {
+	it := NewEmptyIterator()
+
+	_ = it.Close()
+
+	if it.Err() != nil {
+		t.Errorf("unexpected error: %v", it.Err())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Contract compliance: No ordering guarantee tests
+// These tests verify that tests don't accidentally depend on ordering.
+// -----------------------------------------------------------------------------
+
+func TestSegmentFileIterator_NoOrderingGuarantee(t *testing.T) {
+	// This test documents that we make no ordering guarantees.
+	// The implementation happens to iterate in slice order,
+	// but consumers should not rely on this.
+	files := []lode.FileRef{
+		{Path: "c.json", SizeBytes: 100},
+		{Path: "a.json", SizeBytes: 100},
+		{Path: "b.json", SizeBytes: 100},
+	}
+
+	it := NewSegmentFileIterator("mydata", SegmentRef{ID: "snap-1"}, files)
+	defer it.Close()
+
+	var paths []string
+	for it.Next() {
+		paths = append(paths, it.Ref().Path)
+	}
+
+	// We verify we got all 3 paths, but NOT their order
+	if len(paths) != 3 {
+		t.Errorf("expected 3 paths, got %d", len(paths))
+	}
+
+	// Use set comparison, not ordered comparison
+	pathSet := make(map[string]bool)
+	for _, p := range paths {
+		pathSet[p] = true
+	}
+
+	for _, f := range files {
+		if !pathSet[f.Path] {
+			t.Errorf("missing path: %s", f.Path)
+		}
+	}
+}


### PR DESCRIPTION
  Implement ObjectIterator interface per CONTRACT_ITERATION.md:
  - SegmentFileIterator: iterates manifest files
  - ListingIterator: iterates storage listing results
  - EmptyIterator: zero-allocation empty iterator

  Lifecycle guarantees:
  - Next() returns false after exhaustion or Close()
  - Close() is idempotent
  - Err() callable after exhaustion or close
  - Resources released on Close() or exhaustion

  No ordering guarantees; tests use set comparison.