### PR TITLE
feat(read): ✨ add layout-specific dataset enumeration semantics

### DIFF
--- a/internal/read/layout_test.go
+++ b/internal/read/layout_test.go
@@ -346,6 +346,13 @@ func TestHiveLayout_DataFilePath(t *testing.T) {
 // FlatLayout Tests
 // -----------------------------------------------------------------------------
 
+func TestFlatLayout_SupportsDatasetEnumeration(t *testing.T) {
+	layout := FlatLayout{}
+	if layout.SupportsDatasetEnumeration() {
+		t.Error("FlatLayout.SupportsDatasetEnumeration() = true, want false")
+	}
+}
+
 func TestFlatLayout_DatasetsPrefix(t *testing.T) {
 	layout := FlatLayout{}
 	got := layout.DatasetsPrefix()
@@ -437,6 +444,10 @@ type customLayout struct {
 	datasetsPrefix string
 	listCalls      []string
 	getManifestReq []string
+}
+
+func (c *customLayout) SupportsDatasetEnumeration() bool {
+	return c.datasetsPrefix != ""
 }
 
 func (c *customLayout) DatasetsPrefix() string {

--- a/internal/read/reader.go
+++ b/internal/read/reader.go
@@ -52,7 +52,15 @@ func NewReaderWithLayout(store lode.Store, layout Layout) *Reader {
 }
 
 // ListDatasets returns all dataset IDs found in storage.
+//
+// Returns ErrDatasetsNotModeled if the layout doesn't support dataset enumeration
+// (e.g., FlatLayout). An empty list is returned only for truly empty storage.
 func (r *Reader) ListDatasets(ctx context.Context, opts DatasetListOptions) ([]lode.DatasetID, error) {
+	// Check if the layout supports dataset enumeration
+	if !r.layout.SupportsDatasetEnumeration() {
+		return nil, ErrDatasetsNotModeled
+	}
+
 	// List all paths under the datasets prefix
 	paths, err := r.store.List(ctx, r.layout.DatasetsPrefix())
 	if err != nil {

--- a/internal/read/types.go
+++ b/internal/read/types.go
@@ -4,7 +4,19 @@
 // The read API exposes stored facts, not interpretations.
 package read
 
-import "github.com/justapithecus/lode/lode"
+import (
+	"errors"
+
+	"github.com/justapithecus/lode/lode"
+)
+
+// ErrDatasetsNotModeled indicates that the current layout does not support
+// dataset enumeration. Some layouts (e.g., FlatLayout) don't have a common
+// prefix for datasets, making enumeration impossible without listing entire storage.
+//
+// This error is returned by ListDatasets when the layout's
+// SupportsDatasetEnumeration returns false.
+var ErrDatasetsNotModeled = errors.New("datasets not modeled by this layout")
 
 // ObjectKey identifies an object in storage.
 type ObjectKey string


### PR DESCRIPTION
  Milestone 2 - Reader Layout Semantics:

  - Add SupportsDatasetEnumeration() to Layout interface
  - FlatLayout returns ErrDatasetsNotModeled (no common prefix)
  - DefaultLayout/HiveLayout support dataset enumeration
  - Empty list only for truly empty storage
  - Add comprehensive discovery tests for all layouts
  - Tests prove manifest-driven discovery across layouts

  Per CONTRACT_READ_API.md, "manifest presence = commit signal" and
  discovery must be deterministic without inference.