### PR TITLE
feat(layout): ✨ implement HiveLayout partition pruning and semantic noop validation

### DIFF
--- a/docs/contracts/CONTRACT_LAYOUT.md
+++ b/docs/contracts/CONTRACT_LAYOUT.md
@@ -30,6 +30,8 @@ Layout is the **unified abstraction** that governs:
 - **Hive-style layouts** MUST be partition-anchored and enable prefix pruning when a
   partition filter is supplied. Layouts that claim partition-first semantics but require
   full-manifest scans are invalid.
+- **Hive-style layouts** MUST place manifests under partition prefixes when partitioning
+  is in use, so partition-filtered listing cannot miss committed segments.
 
 ---
 
@@ -38,6 +40,9 @@ Layout is the **unified abstraction** that governs:
 - Defines logical partition semantics (keys, values, normalization).
 - Layout determines if/how partition semantics are encoded into paths.
 - MUST be recorded in manifests by name.
+- Layouts that do not support partitions MUST accept any **semantically noop**
+  partitioner (not just one named `"noop"`), and MUST reject partitioners that
+  emit non-empty partition keys.
 
 ---
 

--- a/internal/partition/partition.go
+++ b/internal/partition/partition.go
@@ -85,5 +85,11 @@ func (n *Noop) PartitionKey(_ any) (string, error) {
 	return "", nil
 }
 
+// IsNoop returns true, indicating this partitioner produces no partitions.
+// This implements the dataset.NoopPartitioner marker interface.
+func (n *Noop) IsNoop() bool {
+	return true
+}
+
 // Ensure Noop implements lode.Partitioner
 var _ lode.Partitioner = (*Noop)(nil)

--- a/internal/read/types.go
+++ b/internal/read/types.go
@@ -49,6 +49,12 @@ type ObjectRef struct {
 type SegmentRef struct {
 	// ID is the segment/snapshot identifier.
 	ID lode.SnapshotID
+
+	// Partition is the partition path where this segment's manifest resides.
+	// For partition-first layouts (e.g., HiveLayout), this is populated during
+	// discovery and used to construct the correct manifest path.
+	// Empty for segment-first layouts (e.g., DefaultLayout).
+	Partition PartitionPath
 }
 
 // PartitionRef references a partition within a dataset.


### PR DESCRIPTION
  Milestone B implementation:
  - HiveLayout places manifests under partition prefixes for true prefix pruning
  - Add ManifestPathInPartition and ParsePartitionFromManifest to Layout
  - Add Partition field to SegmentRef for partition-aware manifest loading
  - Dataset writes manifests under each partition for HiveLayout
  - Add NoopPartitioner marker interface for semantic noop check
  - FlatLayout accepts custom noop partitioners implementing IsNoop()

  Stop measures verified:
  - No changes to public API in /lode
  - HiveLayout provides true prefix pruning without losing segments