### PR TITLE
feat(api): ✨ introduce dual-apply Option interface for fail-fast validation

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -67,6 +67,9 @@ reader, _ := lode.NewReader(
 Options are opt-in and composable. They override default components when
 provided.
 
+Options are validated at construction time. Passing an option that does
+not apply to the target (dataset vs reader) returns an error.
+
 Dataset construction uses:
 - StoreFactory
 - Layout
@@ -113,6 +116,9 @@ valid; nil metadata is not.
 
 Errors are returned for invalid configuration, storage failures, or
 missing objects. Error semantics are stable and documented.
+
+`ListDatasets` returns `ErrNoManifests` when storage contains objects but
+no valid manifests.
 
 ---
 

--- a/docs/contracts/CONTRACT_ERRORS.md
+++ b/docs/contracts/CONTRACT_ERRORS.md
@@ -24,12 +24,14 @@ These indicate a requested resource does not exist.
 | `lode.ErrNotFound` | Storage | Object path does not exist |
 | `lode.ErrNotFound` | Read API | Dataset or segment not found (no manifests) |
 | `lode.ErrNoSnapshots` | Dataset | Dataset exists but has no committed snapshots |
+| `lode.ErrNoManifests` | Read API | Storage contains objects but no valid manifests |
 
 **Behavior**:
 - `ListSegments` returns `ErrNotFound` when dataset has no committed manifests.
 - `ListPartitions` returns `ErrNotFound` when dataset has no committed manifests.
 - `GetManifest` returns `ErrNotFound` when manifest path doesn't exist.
 - `Snapshot` returns `ErrNotFound` when snapshot ID doesn't exist.
+ - `ListDatasets` returns `ErrNoManifests` when storage contains objects but no valid manifests.
 
 ---
 
@@ -96,7 +98,7 @@ These indicate storage-level failures.
 | Error | Source | Meaning |
 |-------|--------|---------|
 | `lode.ErrPathExists` | Storage | Attempt to write to existing path (immutability violation) |
-| `storage.ErrInvalidPath` | Storage | Path escapes storage root or is empty |
+| `lode.ErrInvalidPath` | Storage | Path escapes storage root or is empty |
 | `read.ErrRangeReadNotSupported` | Read API | Store doesn't support range reads |
 
 **Behavior**:
@@ -116,7 +118,7 @@ These indicate invalid configuration at setup time.
 | Error | Reader/Dataset | Nil store provided |
 
 **Behavior**:
-- `NewReader(nil)` panics.
+- `NewReader(nil)` returns error.
 - `NewDataset(id, nil)` returns error.
 
 ---

--- a/lode/reader.go
+++ b/lode/reader.go
@@ -53,7 +53,9 @@ func NewReader(factory StoreFactory, opts ...Option) (Reader, error) {
 	}
 
 	for _, opt := range opts {
-		opt(cfg)
+		if err := opt.applyReader(cfg); err != nil {
+			return nil, fmt.Errorf("lode: %w", err)
+		}
 	}
 
 	if cfg.layout == nil {


### PR DESCRIPTION
- Define Option as interface with applyDataset/applyReader methods
- WithLayout implements both (valid for dataset and reader)
- WithCompressor, WithCodec implement only applyDataset
- Invalid options return sentinel errors immediately at construction
- Add ErrOptionNotValidForReader, ErrOptionNotValidForDataset sentinels