### PR TITLE
feat(api): ✨ add range read support to Store and Reader

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -107,6 +107,14 @@ construction.
 - `D` - Shorthand alias for `map[string]any` in callsites and examples
 - `R(...)` - Convenience helper to build `[]any` from record literals
 
+**Range read support:**
+- `Store.ReadRange(ctx, path, offset, length)` - Read byte range from object
+- `Store.ReaderAt(ctx, path)` - Get `io.ReaderAt` for random access
+- `Reader.ReaderAt(ctx, obj)` - Get `io.ReaderAt` for data object
+
+Range reads enable efficient access to columnar formats (Parquet footers),
+block-indexed logs, and partial artifact previews.
+
 ---
 
 ## Metadata

--- a/docs/contracts/CONTRACT_ERRORS.md
+++ b/docs/contracts/CONTRACT_ERRORS.md
@@ -105,7 +105,11 @@ These indicate storage-level failures.
 - `Put` returns `ErrPathExists` if path already exists (enforces immutability).
 - `Put` returns `ErrInvalidPath` for paths that escape root or are empty.
 - `Get` returns `ErrInvalidPath` for invalid paths.
-- `ObjectReaderAt` returns `ErrRangeReadNotSupported` for stores without range capability.
+- `ReadRange` returns `ErrInvalidPath` for:
+  - negative offset or length
+  - length exceeding platform `int` capacity
+  - offset+length overflow
+- `ReaderAt` returns `ErrRangeReadNotSupported` for stores without range capability.
 
 ---
 

--- a/docs/contracts/CONTRACT_STORAGE.md
+++ b/docs/contracts/CONTRACT_STORAGE.md
@@ -37,6 +37,22 @@ It is authoritative for any implementation of the `Store` interface.
 - MUST remove the path if it exists.
 - MUST be safe to call on a missing path (idempotent or `ErrNotFound`).
 
+### ReadRange
+- MUST return bytes from `[offset, offset+length)` for the given path.
+- If the path does not exist, MUST return `ErrNotFound`.
+- If offset or length is negative, MUST return `ErrInvalidPath`.
+- If length exceeds platform `int` capacity, MUST return `ErrInvalidPath`.
+- If offset+length would overflow, MUST return `ErrInvalidPath`.
+- If the range extends beyond EOF, MUST return available bytes (not an error).
+- If offset is beyond EOF, MUST return an empty slice.
+- MUST use true range reads (not whole-file read) where the backend supports it.
+
+### ReaderAt
+- MUST return an `io.ReaderAt` for random access reads.
+- If the path does not exist, MUST return `ErrNotFound`.
+- The returned `ReaderAt` MUST support concurrent reads at different offsets.
+- Callers are responsible for closing the underlying resource if it implements `io.Closer`.
+
 ---
 
 ## Commit Semantics

--- a/lode/reader.go
+++ b/lode/reader.go
@@ -203,6 +203,10 @@ func (r *reader) OpenObject(ctx context.Context, obj ObjectRef) (io.ReadCloser, 
 	return r.store.Get(ctx, obj.Path)
 }
 
+func (r *reader) ReaderAt(ctx context.Context, obj ObjectRef) (io.ReaderAt, error) {
+	return r.store.ReaderAt(ctx, obj.Path)
+}
+
 func (r *reader) loadManifest(ctx context.Context, manifestPath string) (*Manifest, error) {
 	rc, err := r.store.Get(ctx, manifestPath)
 	if err != nil {

--- a/lode/store.go
+++ b/lode/store.go
@@ -1,9 +1,11 @@
 package lode
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,10 @@ import (
 
 // ErrInvalidPath indicates a path that would escape the storage root.
 var ErrInvalidPath = errors.New("invalid path: escapes storage root")
+
+// maxReadRangeLength is the maximum length for ReadRange to prevent overflow
+// when converting int64 to int on 32-bit platforms.
+const maxReadRangeLength = int64(math.MaxInt)
 
 // -----------------------------------------------------------------------------
 // Filesystem Store
@@ -142,6 +148,57 @@ func (f *fsStore) Delete(_ context.Context, path string) error {
 		return nil
 	}
 	return err
+}
+
+func (f *fsStore) ReadRange(_ context.Context, path string, offset, length int64) ([]byte, error) {
+	if offset < 0 || length < 0 || length > maxReadRangeLength {
+		return nil, ErrInvalidPath
+	}
+	// Check for offset+length overflow
+	if offset > math.MaxInt64-length {
+		return nil, ErrInvalidPath
+	}
+
+	fullPath, err := f.safePathForFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	data := make([]byte, int(length))
+	n, err := file.ReadAt(data, offset)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return data[:n], nil
+}
+
+func (f *fsStore) ReaderAt(_ context.Context, path string) (io.ReaderAt, error) {
+	fullPath, err := f.safePathForFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	// Note: The caller is responsible for closing via type assertion if needed.
+	// *os.File implements io.ReaderAt.
+	return file, nil
 }
 
 func (f *fsStore) safePathForFile(path string) (string, error) {
@@ -304,6 +361,63 @@ func (m *memoryStore) Delete(_ context.Context, path string) error {
 	m.mu.Unlock()
 
 	return nil
+}
+
+func (m *memoryStore) ReadRange(_ context.Context, path string, offset, length int64) ([]byte, error) {
+	if offset < 0 || length < 0 || length > maxReadRangeLength {
+		return nil, ErrInvalidPath
+	}
+	// Check for offset+length overflow
+	if offset > math.MaxInt64-length {
+		return nil, ErrInvalidPath
+	}
+
+	normalized, valid := normalizePathForFile(path)
+	if !valid {
+		return nil, ErrInvalidPath
+	}
+
+	m.mu.RLock()
+	data, exists := m.data[normalized]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil, ErrNotFound
+	}
+
+	// Bounds checking
+	if offset >= int64(len(data)) {
+		return []byte{}, nil
+	}
+
+	end := offset + length
+	if end > int64(len(data)) {
+		end = int64(len(data))
+	}
+
+	result := make([]byte, int(end-offset))
+	copy(result, data[offset:end])
+	return result, nil
+}
+
+func (m *memoryStore) ReaderAt(_ context.Context, path string) (io.ReaderAt, error) {
+	normalized, valid := normalizePathForFile(path)
+	if !valid {
+		return nil, ErrInvalidPath
+	}
+
+	m.mu.RLock()
+	data, exists := m.data[normalized]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil, ErrNotFound
+	}
+
+	// Return a bytes.Reader which implements io.ReaderAt
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	return bytes.NewReader(dataCopy), nil
 }
 
 func normalizePathForFile(path string) (string, bool) {


### PR DESCRIPTION
- Add ReadRange(ctx, path, offset, length) to Store interface
- Add ReaderAt(ctx, path) to Store interface
- Add ReaderAt(ctx, obj) to Reader interface
- Add ErrRangeReadNotSupported sentinel error
- Implement range reads for FS store (uses file.ReadAt)
- Implement range reads for Memory store (byte slicing)
- Update CONTRACT_STORAGE.md with range read obligations
- Update PUBLIC_API.md with range read documentation
- Fix stale read.ManifestValidationError reference in CONTRACT_ERRORS.md