### PR TITLE
test(lode): ✅ add comprehensive test coverage for Milestone G

### DIFF
--- a/lode/dataset_test.go
+++ b/lode/dataset_test.go
@@ -1,0 +1,153 @@
+package lode
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// -----------------------------------------------------------------------------
+// G4: Raw blob + partitioning rejection test
+// -----------------------------------------------------------------------------
+
+func TestNewDataset_RawBlobWithPartitioner_ReturnsError(t *testing.T) {
+	// Per CONTRACT_LAYOUT.md and the implementation, raw blob mode (no codec)
+	// cannot use partitioning because there are no record fields to extract keys from.
+	//
+	// NewHiveLayout creates a layout with a non-noop partitioner (hive partitioning).
+	// Using it without a codec should return an error.
+
+	hiveLayout := NewHiveLayout("day") // Non-noop partitioner
+
+	_, err := NewDataset("test-ds", NewMemoryFactory(), WithLayout(hiveLayout))
+	if err == nil {
+		t.Fatal("expected error for raw blob mode with partitioner, got nil")
+	}
+	if !strings.Contains(err.Error(), "raw blob mode") {
+		t.Errorf("expected error message about raw blob mode, got: %v", err)
+	}
+}
+
+func TestNewDataset_RawBlobWithDefaultLayout_Success(t *testing.T) {
+	// DefaultLayout uses noop partitioner, so raw blob mode should work.
+	ds, err := NewDataset("test-ds", NewMemoryFactory())
+	if err != nil {
+		t.Fatalf("expected success for raw blob with default layout, got: %v", err)
+	}
+	if ds == nil {
+		t.Fatal("expected non-nil dataset")
+	}
+}
+
+func TestNewDataset_NilFactory_ReturnsError(t *testing.T) {
+	_, err := NewDataset("test-ds", nil)
+	if err == nil {
+		t.Fatal("expected error for nil factory, got nil")
+	}
+}
+
+func TestNewDataset_FactoryReturnsNil_ReturnsError(t *testing.T) {
+	nilFactory := func() (Store, error) {
+		return nil, nil
+	}
+
+	_, err := NewDataset("test-ds", nilFactory)
+	if err == nil {
+		t.Fatal("expected error for factory returning nil, got nil")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Option validation tests
+// -----------------------------------------------------------------------------
+
+func TestReader_WithCompressor_ReturnsError(t *testing.T) {
+	// WithCompressor is a dataset-only option
+	_, err := NewReader(NewMemoryFactory(), WithCompressor(NewNoOpCompressor()))
+	if err == nil {
+		t.Fatal("expected error for WithCompressor on reader, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid for reader") {
+		t.Errorf("expected 'not valid for reader' error, got: %v", err)
+	}
+}
+
+func TestReader_WithCodec_ReturnsError(t *testing.T) {
+	// WithCodec is a dataset-only option
+	_, err := NewReader(NewMemoryFactory(), WithCodec(&testCodec{}))
+	if err == nil {
+		t.Fatal("expected error for WithCodec on reader, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid for reader") {
+		t.Errorf("expected 'not valid for reader' error, got: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Write validation tests
+// -----------------------------------------------------------------------------
+
+func TestDataset_Write_NilMetadata_ReturnsError(t *testing.T) {
+	ds, err := NewDataset("test-ds", NewMemoryFactory())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ds.Write(context.Background(), []any{[]byte("data")}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil metadata, got nil")
+	}
+	if !strings.Contains(err.Error(), "metadata must be non-nil") {
+		t.Errorf("expected metadata error, got: %v", err)
+	}
+}
+
+func TestDataset_RawBlobWrite_MultipleElements_ReturnsError(t *testing.T) {
+	ds, err := NewDataset("test-ds", NewMemoryFactory())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Raw blob mode requires exactly one []byte element
+	_, err = ds.Write(context.Background(), []any{[]byte("one"), []byte("two")}, Metadata{})
+	if err == nil {
+		t.Fatal("expected error for multiple elements in raw blob mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "exactly one data element") {
+		t.Errorf("expected 'exactly one data element' error, got: %v", err)
+	}
+}
+
+func TestDataset_RawBlobWrite_WrongType_ReturnsError(t *testing.T) {
+	ds, err := NewDataset("test-ds", NewMemoryFactory())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Raw blob mode requires []byte, not string
+	_, err = ds.Write(context.Background(), []any{"not a byte slice"}, Metadata{})
+	if err == nil {
+		t.Fatal("expected error for wrong type in raw blob mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires []byte") {
+		t.Errorf("expected '[]byte' error, got: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+// testCodec is a simple codec for testing.
+type testCodec struct{}
+
+func (c *testCodec) Name() string { return "test-codec" }
+
+func (c *testCodec) Encode(w io.Writer, records []any) error {
+	return nil
+}
+
+func (c *testCodec) Decode(r io.Reader) ([]any, error) {
+	return nil, nil
+}

--- a/lode/reader_test.go
+++ b/lode/reader_test.go
@@ -1,0 +1,223 @@
+package lode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// -----------------------------------------------------------------------------
+// G2: Manifest validation tests
+// -----------------------------------------------------------------------------
+
+func TestReader_GetManifest_InvalidManifest_MissingSchemaName(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	manifest := &Manifest{
+		// SchemaName missing
+		FormatVersion: "1.0.0",
+		DatasetID:     "test-ds",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      Metadata{},
+		Files:         []FileRef{},
+		RowCount:      0,
+		Compressor:    "noop",
+		Partitioner:   "noop",
+	}
+	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = reader.GetManifest(ctx, "test-ds", SegmentRef{ID: "snap-1"})
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestReader_GetManifest_InvalidManifest_MissingFormatVersion(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	manifest := &Manifest{
+		SchemaName: "lode-manifest",
+		// FormatVersion missing
+		DatasetID:   "test-ds",
+		SnapshotID:  "snap-1",
+		CreatedAt:   time.Now().UTC(),
+		Metadata:    Metadata{},
+		Files:       []FileRef{},
+		RowCount:    0,
+		Compressor:  "noop",
+		Partitioner: "noop",
+	}
+	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = reader.GetManifest(ctx, "test-ds", SegmentRef{ID: "snap-1"})
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestReader_GetManifest_InvalidManifest_NilMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	manifest := &Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "test-ds",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      nil, // nil not allowed
+		Files:         []FileRef{},
+		RowCount:      0,
+		Compressor:    "noop",
+		Partitioner:   "noop",
+	}
+	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = reader.GetManifest(ctx, "test-ds", SegmentRef{ID: "snap-1"})
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestReader_ListSegments_InvalidManifest_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	// Write an invalid manifest (missing required fields)
+	manifest := &Manifest{
+		// SchemaName missing - invalid
+		DatasetID:  "test-ds",
+		SnapshotID: "snap-1",
+	}
+	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Must provide partition filter to trigger manifest loading/validation.
+	// Without partition filter, ListSegments only parses paths without loading manifests.
+	_, err = reader.ListSegments(ctx, "test-ds", "some-partition", SegmentListOptions{})
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Errorf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// G3: ErrNoManifests test
+// -----------------------------------------------------------------------------
+
+func TestReader_ListDatasets_ErrNoManifests(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	// Write data files but no manifest
+	err := store.Put(ctx, "datasets/test-ds/snapshots/snap-1/data/file.txt", bytes.NewReader([]byte("data")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = reader.ListDatasets(ctx, DatasetListOptions{})
+	if !errors.Is(err, ErrNoManifests) {
+		t.Errorf("expected ErrNoManifests, got: %v", err)
+	}
+}
+
+func TestReader_ListDatasets_EmptyStorage(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	datasets, err := reader.ListDatasets(ctx, DatasetListOptions{})
+	if err != nil {
+		t.Fatalf("expected no error for empty storage, got: %v", err)
+	}
+	if len(datasets) != 0 {
+		t.Errorf("expected empty list, got: %v", datasets)
+	}
+}
+
+func TestReader_ListDatasets_WithValidManifest(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	manifest := &Manifest{
+		SchemaName:    "lode-manifest",
+		FormatVersion: "1.0.0",
+		DatasetID:     "test-ds",
+		SnapshotID:    "snap-1",
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      Metadata{},
+		Files:         []FileRef{},
+		RowCount:      0,
+		Compressor:    "noop",
+		Partitioner:   "noop",
+	}
+	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+
+	reader, err := NewReader(NewMemoryFactoryFrom(store))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	datasets, err := reader.ListDatasets(ctx, DatasetListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(datasets) != 1 || datasets[0] != "test-ds" {
+		t.Errorf("expected [test-ds], got: %v", datasets)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------------
+
+// NewMemoryFactoryFrom creates a StoreFactory that returns an existing store.
+func NewMemoryFactoryFrom(store Store) StoreFactory {
+	return func() (Store, error) {
+		return store, nil
+	}
+}
+
+func writeManifest(t *testing.T, ctx context.Context, store Store, path string, m *Manifest) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(ctx, path, bytes.NewReader(data)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/lode/store_test.go
+++ b/lode/store_test.go
@@ -1,0 +1,464 @@
+package lode
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math"
+	"os"
+	"testing"
+)
+
+// -----------------------------------------------------------------------------
+// G1: Immutability tests - Put returns ErrPathExists on overwrite
+// -----------------------------------------------------------------------------
+
+func TestFSStore_Put_ErrPathExists(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First write should succeed
+	err = store.Put(ctx, "test/file.txt", bytes.NewReader([]byte("hello")))
+	if err != nil {
+		t.Fatalf("first Put failed: %v", err)
+	}
+
+	// Second write to same path should return ErrPathExists
+	err = store.Put(ctx, "test/file.txt", bytes.NewReader([]byte("world")))
+	if !errors.Is(err, ErrPathExists) {
+		t.Errorf("expected ErrPathExists, got: %v", err)
+	}
+}
+
+func TestMemoryStore_Put_ErrPathExists(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	// First write should succeed
+	err := store.Put(ctx, "test/file.txt", bytes.NewReader([]byte("hello")))
+	if err != nil {
+		t.Fatalf("first Put failed: %v", err)
+	}
+
+	// Second write to same path should return ErrPathExists
+	err = store.Put(ctx, "test/file.txt", bytes.NewReader([]byte("world")))
+	if !errors.Is(err, ErrPathExists) {
+		t.Errorf("expected ErrPathExists, got: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// G5: Range read tests
+// -----------------------------------------------------------------------------
+
+func TestFSStore_ReadRange_Basic(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("hello world")
+	err = store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read middle portion
+	data, err := store.ReadRange(ctx, "test.txt", 6, 5)
+	if err != nil {
+		t.Fatalf("ReadRange failed: %v", err)
+	}
+	if string(data) != "world" {
+		t.Errorf("expected 'world', got %q", string(data))
+	}
+}
+
+func TestFSStore_ReadRange_BeyondEOF(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("hello")
+	err = store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read beyond EOF - should return available bytes
+	data, err := store.ReadRange(ctx, "test.txt", 3, 100)
+	if err != nil {
+		t.Fatalf("ReadRange failed: %v", err)
+	}
+	if string(data) != "lo" {
+		t.Errorf("expected 'lo', got %q", string(data))
+	}
+}
+
+func TestFSStore_ReadRange_OffsetBeyondEOF(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("hello")
+	err = store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Offset beyond EOF - should return empty slice (EOF behavior from ReadAt)
+	data, err := store.ReadRange(ctx, "test.txt", 100, 10)
+	if err != nil {
+		t.Fatalf("ReadRange failed: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty slice, got %d bytes", len(data))
+	}
+}
+
+func TestFSStore_ReadRange_NotFound(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.ReadRange(ctx, "nonexistent.txt", 0, 10)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestFSStore_ReadRange_NegativeOffset(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.ReadRange(ctx, "test.txt", -1, 10)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for negative offset, got: %v", err)
+	}
+}
+
+func TestFSStore_ReadRange_NegativeLength(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.ReadRange(ctx, "test.txt", 0, -1)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for negative length, got: %v", err)
+	}
+}
+
+func TestFSStore_ReadRange_LengthOverflow(t *testing.T) {
+	// This test validates 32-bit platform protection.
+	// On 64-bit systems, math.MaxInt == math.MaxInt64, so the overflow check
+	// cannot trigger. Skip on 64-bit.
+	if math.MaxInt == math.MaxInt64 {
+		t.Skip("length overflow check only applies to 32-bit platforms")
+	}
+
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Length exceeding maxInt (only relevant on 32-bit)
+	_, err = store.ReadRange(ctx, "test.txt", 0, math.MaxInt64)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for length overflow, got: %v", err)
+	}
+}
+
+func TestFSStore_ReadRange_OffsetPlusLengthOverflow(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// offset + length would overflow int64
+	_, err = store.ReadRange(ctx, "test.txt", math.MaxInt64-10, 20)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for offset+length overflow, got: %v", err)
+	}
+}
+
+func TestFSStore_ReaderAt_Basic(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("hello world")
+	err = store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ra, err := store.ReaderAt(ctx, "test.txt")
+	if err != nil {
+		t.Fatalf("ReaderAt failed: %v", err)
+	}
+	// fsStore.ReaderAt returns *os.File which implements io.Closer
+	if closer, ok := ra.(interface{ Close() error }); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	buf := make([]byte, 5)
+	n, err := ra.ReadAt(buf, 6)
+	if err != nil {
+		t.Fatalf("ReadAt failed: %v", err)
+	}
+	if n != 5 || string(buf) != "world" {
+		t.Errorf("expected 'world', got %q", string(buf[:n]))
+	}
+}
+
+func TestFSStore_ReaderAt_NotFound(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := os.MkdirTemp("", "lode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFS(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.ReaderAt(ctx, "nonexistent.txt")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// Memory store tests
+
+func TestMemoryStore_ReadRange_Basic(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	content := []byte("hello world")
+	err := store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := store.ReadRange(ctx, "test.txt", 6, 5)
+	if err != nil {
+		t.Fatalf("ReadRange failed: %v", err)
+	}
+	if string(data) != "world" {
+		t.Errorf("expected 'world', got %q", string(data))
+	}
+}
+
+func TestMemoryStore_ReadRange_BeyondEOF(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	content := []byte("hello")
+	err := store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := store.ReadRange(ctx, "test.txt", 3, 100)
+	if err != nil {
+		t.Fatalf("ReadRange failed: %v", err)
+	}
+	if string(data) != "lo" {
+		t.Errorf("expected 'lo', got %q", string(data))
+	}
+}
+
+func TestMemoryStore_ReadRange_OffsetBeyondEOF(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	content := []byte("hello")
+	err := store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := store.ReadRange(ctx, "test.txt", 100, 10)
+	if err != nil {
+		t.Fatalf("ReadRange failed: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty slice, got %d bytes", len(data))
+	}
+}
+
+func TestMemoryStore_ReadRange_NotFound(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	_, err := store.ReadRange(ctx, "nonexistent.txt", 0, 10)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestMemoryStore_ReadRange_NegativeOffset(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	_, err := store.ReadRange(ctx, "test.txt", -1, 10)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for negative offset, got: %v", err)
+	}
+}
+
+func TestMemoryStore_ReadRange_NegativeLength(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	_, err := store.ReadRange(ctx, "test.txt", 0, -1)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for negative length, got: %v", err)
+	}
+}
+
+func TestMemoryStore_ReadRange_LengthOverflow(t *testing.T) {
+	// This test validates 32-bit platform protection.
+	// On 64-bit systems, math.MaxInt == math.MaxInt64, so the overflow check
+	// cannot trigger. Skip on 64-bit.
+	if math.MaxInt == math.MaxInt64 {
+		t.Skip("length overflow check only applies to 32-bit platforms")
+	}
+
+	ctx := context.Background()
+	store := NewMemory()
+
+	_, err := store.ReadRange(ctx, "test.txt", 0, math.MaxInt64)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for length overflow, got: %v", err)
+	}
+}
+
+func TestMemoryStore_ReadRange_OffsetPlusLengthOverflow(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	_, err := store.ReadRange(ctx, "test.txt", math.MaxInt64-10, 20)
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("expected ErrInvalidPath for offset+length overflow, got: %v", err)
+	}
+}
+
+func TestMemoryStore_ReaderAt_Basic(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	content := []byte("hello world")
+	err := store.Put(ctx, "test.txt", bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ra, err := store.ReaderAt(ctx, "test.txt")
+	if err != nil {
+		t.Fatalf("ReaderAt failed: %v", err)
+	}
+	// Close if the ReaderAt implements io.Closer (consistency with fsStore pattern)
+	if closer, ok := ra.(interface{ Close() error }); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	buf := make([]byte, 5)
+	n, err := ra.ReadAt(buf, 6)
+	if err != nil {
+		t.Fatalf("ReadAt failed: %v", err)
+	}
+	if n != 5 || string(buf) != "world" {
+		t.Errorf("expected 'world', got %q", string(buf[:n]))
+	}
+}
+
+func TestMemoryStore_ReaderAt_NotFound(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+
+	_, err := store.ReaderAt(ctx, "nonexistent.txt")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}


### PR DESCRIPTION
- G1: Immutability tests (ErrPathExists on overwrite)
- G2: Manifest validation tests (missing fields return ErrManifestInvalid)
- G3: ErrNoManifests test (objects without manifests)
- G4: Raw blob + partitioning rejection (no codec + non-noop partitioner)
- G5: Range read tests (ReadRange, ReaderAt, bounds, overflow)
- G6: Verified all examples compile and run
- Fix FD leak in ReaderAt tests (close *os.File via type assertion)