### PR TITLE
fix(ci): 🐛 resolve lint errors in store and test files

### DIFF
--- a/lode/dataset_test.go
+++ b/lode/dataset_test.go
@@ -49,7 +49,7 @@ func TestNewDataset_NilFactory_ReturnsError(t *testing.T) {
 
 func TestNewDataset_FactoryReturnsNil_ReturnsError(t *testing.T) {
 	nilFactory := func() (Store, error) {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentionally testing nil store with nil error
 	}
 
 	_, err := NewDataset("test-ds", nilFactory)
@@ -144,10 +144,10 @@ type testCodec struct{}
 
 func (c *testCodec) Name() string { return "test-codec" }
 
-func (c *testCodec) Encode(w io.Writer, records []any) error {
+func (c *testCodec) Encode(_ io.Writer, _ []any) error {
 	return nil
 }
 
-func (c *testCodec) Decode(r io.Reader) ([]any, error) {
-	return nil, nil
+func (c *testCodec) Decode(_ io.Reader) ([]any, error) {
+	return nil, nil //nolint:nilnil // stub for testing
 }

--- a/lode/reader_test.go
+++ b/lode/reader_test.go
@@ -29,7 +29,7 @@ func TestReader_GetManifest_InvalidManifest_MissingSchemaName(t *testing.T) {
 		Compressor:    "noop",
 		Partitioner:   "noop",
 	}
-	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+	writeManifest(ctx, t, store, manifest)
 
 	reader, err := NewReader(NewMemoryFactoryFrom(store))
 	if err != nil {
@@ -58,7 +58,7 @@ func TestReader_GetManifest_InvalidManifest_MissingFormatVersion(t *testing.T) {
 		Compressor:  "noop",
 		Partitioner: "noop",
 	}
-	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+	writeManifest(ctx, t, store, manifest)
 
 	reader, err := NewReader(NewMemoryFactoryFrom(store))
 	if err != nil {
@@ -87,7 +87,7 @@ func TestReader_GetManifest_InvalidManifest_NilMetadata(t *testing.T) {
 		Compressor:    "noop",
 		Partitioner:   "noop",
 	}
-	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+	writeManifest(ctx, t, store, manifest)
 
 	reader, err := NewReader(NewMemoryFactoryFrom(store))
 	if err != nil {
@@ -110,7 +110,7 @@ func TestReader_ListSegments_InvalidManifest_ReturnsError(t *testing.T) {
 		DatasetID:  "test-ds",
 		SnapshotID: "snap-1",
 	}
-	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+	writeManifest(ctx, t, store, manifest)
 
 	reader, err := NewReader(NewMemoryFactoryFrom(store))
 	if err != nil {
@@ -184,7 +184,7 @@ func TestReader_ListDatasets_WithValidManifest(t *testing.T) {
 		Compressor:    "noop",
 		Partitioner:   "noop",
 	}
-	writeManifest(t, ctx, store, "datasets/test-ds/snapshots/snap-1/manifest.json", manifest)
+	writeManifest(ctx, t, store, manifest)
 
 	reader, err := NewReader(NewMemoryFactoryFrom(store))
 	if err != nil {
@@ -211,12 +211,13 @@ func NewMemoryFactoryFrom(store Store) StoreFactory {
 	}
 }
 
-func writeManifest(t *testing.T, ctx context.Context, store Store, path string, m *Manifest) {
+func writeManifest(ctx context.Context, t *testing.T, store Store, m *Manifest) {
 	t.Helper()
 	data, err := json.Marshal(m)
 	if err != nil {
 		t.Fatal(err)
 	}
+	path := "datasets/" + string(m.DatasetID) + "/snapshots/" + string(m.SnapshotID) + "/manifest.json"
 	if err := store.Put(ctx, path, bytes.NewReader(data)); err != nil {
 		t.Fatal(err)
 	}

--- a/lode/store.go
+++ b/lode/store.go
@@ -175,7 +175,7 @@ func (f *fsStore) ReadRange(_ context.Context, path string, offset, length int64
 
 	data := make([]byte, int(length))
 	n, err := file.ReadAt(data, offset)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 

--- a/lode/store_test.go
+++ b/lode/store_test.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"os"
 	"testing"
+
+	"github.com/justapithecus/lode/internal/testutil"
 )
 
 // -----------------------------------------------------------------------------
@@ -19,7 +21,7 @@ func TestFSStore_Put_ErrPathExists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -66,7 +68,7 @@ func TestFSStore_ReadRange_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -95,7 +97,7 @@ func TestFSStore_ReadRange_BeyondEOF(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -124,7 +126,7 @@ func TestFSStore_ReadRange_OffsetBeyondEOF(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -153,7 +155,7 @@ func TestFSStore_ReadRange_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -172,7 +174,7 @@ func TestFSStore_ReadRange_NegativeOffset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -191,7 +193,7 @@ func TestFSStore_ReadRange_NegativeLength(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -217,7 +219,7 @@ func TestFSStore_ReadRange_LengthOverflow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -237,7 +239,7 @@ func TestFSStore_ReadRange_OffsetPlusLengthOverflow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -257,7 +259,7 @@ func TestFSStore_ReaderAt_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {
@@ -295,7 +297,7 @@ func TestFSStore_ReaderAt_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer testutil.RemoveAll(tmpDir)
 
 	store, err := NewFS(tmpDir)
 	if err != nil {


### PR DESCRIPTION
- Use testutil.RemoveAll for deferred cleanup in store_test.go
- Use errors.Is for io.EOF comparison in ReadRange (errorlint)
- Remove unused path parameter from writeManifest helper (unparam)
- Add nolint directives for intentional nil returns in test stubs
- Use blank identifier for unused parameters in test codec