### PR TITLE
fix(api): 🐛 address contract gaps for v0.1.0 release

### DIFF
--- a/docs/contracts/CONTRACT_CORE.md
+++ b/docs/contracts/CONTRACT_CORE.md
@@ -52,9 +52,13 @@ Minimum required fields:
 - list of files with sizes and checksums (if available)
 - parent snapshot ID (when applicable)
 - row/event count (total data units in snapshot)
-- min/max timestamp (when data units are timestamped; omit if not applicable)
+- min/max timestamp (when data units implement `Timestamped`; omit if not applicable)
 Optional fields:
 - codec name (omit when no codec is configured)
+
+**v0.1.0 implementation note**: Checksums are not yet computed during writes.
+The `FileRef.Checksum` field exists for forward compatibility but is omitted
+in manifests written by the current implementation.
 
 Manifests are immutable once written.
 

--- a/docs/contracts/CONTRACT_READ_API.md
+++ b/docs/contracts/CONTRACT_READ_API.md
@@ -56,6 +56,21 @@ type Storage interface {
 - `ReaderAt` should implement page-aligned caching and request coalescing.
 - Adapters must document consistency guarantees and mitigations.
 
+### Range read access paths
+
+The `Reader` façade provides `ReaderAt(ctx, ObjectRef)` for random access reads.
+Callers needing direct byte-range reads have two options:
+
+1. **Via Reader.ReaderAt**: Returns `io.ReaderAt` for standard random access.
+   Suitable for most use cases (Parquet footers, block indexes, etc.).
+
+2. **Via Store.ReadRange**: Direct byte-range reads on the underlying store.
+   Callers with access to the `Store` interface can use `ReadRange(ctx, path, offset, length)`.
+
+The `Reader` interface intentionally omits a direct `ReadRange` method because
+`io.ReaderAt` covers the majority of range-read use cases and provides a
+standard Go interface for interoperability with existing libraries.
+
 ---
 
 ## ReaderAt Caching (Recommended)

--- a/docs/contracts/CONTRACT_WRITE_API.md
+++ b/docs/contracts/CONTRACT_WRITE_API.md
@@ -36,6 +36,17 @@ It is authoritative for any `Dataset` implementation.
 - When no codec is configured, each write represents a single data unit and
   the row/event count MUST be `1`.
 
+### Timestamp computation
+
+- When records implement the `Timestamped` interface, `Write` MUST compute
+  `MinTimestamp` and `MaxTimestamp` from the data.
+- Timestamps are extracted by calling `Timestamp()` on each record that
+  implements the interface.
+- Records that do not implement `Timestamped` are ignored for timestamp
+  computation.
+- When no records implement `Timestamped`, both timestamp fields MUST be `nil`.
+- Timestamp computation is explicit (via interface implementation), not inferred.
+
 ### Empty dataset behavior
 
 - The first successful write creates the initial snapshot.
@@ -49,6 +60,23 @@ It is authoritative for any `Dataset` implementation.
 
 - A snapshot is visible only after its manifest is persisted.
 - Manifest presence is the commit signal.
+
+---
+
+## Concurrency
+
+Lode does not implement concurrent multi-writer conflict resolution.
+
+**Single writer or external coordination required.**
+
+- Concurrent writes from multiple processes to the same dataset may produce
+  inconsistent history (e.g., two snapshots with the same parent).
+- Callers MUST ensure at most one writer is active per dataset at any time.
+- External coordination (locks, queues, leader election) is the caller's
+  responsibility.
+
+Lode guarantees safety within a single writer but does not detect or resolve
+conflicts between multiple concurrent writers.
 
 ---
 

--- a/lode/api.go
+++ b/lode/api.go
@@ -39,6 +39,14 @@ func R(records ...D) []any {
 	return out
 }
 
+// Timestamped is implemented by records that have an associated timestamp.
+// When records passed to Dataset.Write implement this interface, the manifest's
+// MinTimestamp and MaxTimestamp fields are automatically computed from the data.
+// Records that do not implement this interface are ignored for timestamp tracking.
+type Timestamped interface {
+	Timestamp() time.Time
+}
+
 // -----------------------------------------------------------------------------
 // Manifest
 // -----------------------------------------------------------------------------

--- a/lode/reader.go
+++ b/lode/reader.go
@@ -166,11 +166,14 @@ func (r *reader) ListSegments(ctx context.Context, dataset DatasetID, partition 
 
 		manifestPartition := r.layout.parsePartitionFromManifest(p)
 
+		// Always validate manifest per CONTRACT_READ_API.md
+		manifest, err := r.loadManifest(ctx, p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load manifest %s: %w", p, err)
+		}
+
+		// Apply partition filter if specified
 		if partition != "" && manifestPartition == "" {
-			manifest, err := r.loadManifest(ctx, p)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load manifest %s: %w", p, err)
-			}
 			if !r.segmentContainsPartition(manifest, partition) {
 				continue
 			}


### PR DESCRIPTION
- Add Timestamped interface for automatic min/max timestamp computation during writes. Records implementing Timestamp() time.Time have their time bounds tracked in the manifest.

- Fix ListSegments to always validate manifests, not just when partition filter is applied. Per CONTRACT_READ_API.md, invalid manifests must return errors.

- Document single-writer requirement in CONTRACT_WRITE_API.md (concurrent multi-writer conflict resolution is explicitly a non-goal).

- Document checksum support status (not yet implemented in v0.1.0).

- Document range read access paths (Reader.ReaderAt vs Store.ReadRange).

- Add comprehensive Timestamped interface documentation to PUBLIC_API.md and CONTRACT_WRITE_API.md.