### PR TITLE
feat(s3): ✨ temp file spooling for atomic 5GB uploads

### DIFF
--- a/docs/contracts/CONTRACT_ERRORS.md
+++ b/docs/contracts/CONTRACT_ERRORS.md
@@ -115,12 +115,13 @@ These indicate storage-level failures.
 
 | Put Path | Detection | Guarantee |
 |----------|-----------|-----------|
-| One-shot (≤ threshold) | Atomic conditional write | Always detected |
+| Atomic (≤ threshold) | Conditional write | Always detected |
 | Multipart (> threshold) | Preflight existence check | Best-effort (TOCTOU window) |
 
 The multipart path has a TOCTOU window between preflight check and upload completion.
 Under concurrent writers without external coordination, an existing path may not be
-detected and data may be overwritten. Single-writer semantics are required.
+detected and data may be overwritten. Single-writer semantics or external coordination required.
+Threshold values are adapter-specific; consult adapter documentation.
 
 ---
 


### PR DESCRIPTION
Replace 100MB memory buffering with temp file spooling to achieve:
- Atomic no-overwrite (via If-None-Match) for uploads up to 5GB
- O(1) memory usage regardless of upload size
- Multipart path (with TOCTOU caveat) only for >5GB payloads

Changes:
- Put() now spools to temp file, determines size, routes to atomic or multipart
- Atomic path (≤5GB): putAtomicFromFile with If-None-Match conditional write
- Multipart path (>5GB): putMultipartFromFile with preflight existence check
- Contracts updated to document 5GB threshold and TOCTOU semantics
- Tests use atomicPutThreshold override (1MB) to avoid 5GB test files
- Added temp file cleanup verification tests