### PR TITLE
docs(api): 📝 align user guarantees with storage and write contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ Lode is built around a small set of invariants:
 - **Writes produce snapshots**
 - **Snapshots reference manifests**
 - **Manifests describe data files and metadata**
+- **Manifest presence is the commit signal** — a snapshot is visible only after its manifest is persisted
 - **Metadata is explicit, persisted, and self-describing (never inferred)**
 - **Storage, format, compression, and partitioning are orthogonal**
+- **Single-writer semantics required** — Lode does not resolve concurrent writer conflicts
 
 If you know the snapshot ID, you know exactly what data you are reading.
 


### PR DESCRIPTION
README.md:
- Add "manifest presence is the commit signal" to core invariants
- Add "single-writer semantics required" to core invariants

PUBLIC_API.md:
- Add "Safety Guarantees" section covering:
  - Commit semantics (manifest-as-commit-signal)
  - Single-writer requirement
  - TOCTOU caveat for large uploads (>5GB on S3)
  - Best-effort cleanup behavior
- Update Usage Gotchas to reference Safety Guarantees

These guarantees were documented in contracts but not surfaced in user-facing documentation. Closes the documentation gap identified during v0.3.0 hardening.