### PR TITLE
docs(changelog): 📝 adopt structured keep-a-changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,133 @@
-# CHANGELOG
+# Changelog
 
-## v0.2.0 — 2026-02-03
-- S3 adapter is now part of the public API under `lode/s3`, with docs and examples for AWS S3, MinIO, LocalStack, and Cloudflare R2.
-- Project is now licensed under Apache 2.0.
-- README now lists supported backends and the license.
-- `CHANGELOG.md` added for release tracking.
+All notable changes to Lode will be documented in this file.
 
-## v0.1.0 — 2026-02-03
-- Public API for datasets and readers, immutable snapshots, manifests, and explicit metadata.
-- Layout system with default, hive, and flat layouts; dataset enumeration and partition-pruning semantics.
-- Storage adapters for filesystem and in-memory; experimental S3 adapter under `internal/`.
-- Codec/compression: JSONL codec, gzip compressor, and no-op defaults.
-- Range-read support (`ReadRange`, `ReaderAt`) for partial object access.
-- Examples covering default layout, hive layout, manifest-driven discovery, blob upload, and S3 experimental.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Notable internal work
-- Contract alignment for read/write semantics, manifest validation, iterator lifecycle compliance, and cross-adapter consistency tests.
-- CI/release automation and tooling setup.
+---
+
+## [Unreleased]
+
+### Added
+
+- N/A
+
+### Changed
+
+- N/A
+
+### Fixed
+
+- N/A
+
+### Breaking Changes
+
+- None
+
+### Known Limitations
+
+- G3-4: Context cancellation cleanup behavior is nondeterministic; documented as residual risk
+
+### Upgrade Notes
+
+- N/A
+
+### References
+
+- [PUBLIC_API.md](PUBLIC_API.md) — User-facing API documentation
+- [docs/contracts/](docs/contracts/) — Normative contract specifications
+
+---
+
+## [0.2.0] - 2026-02-03
+
+### Added
+
+- **S3 Adapter**: Now part of public API under `lode/s3`
+- **S3 Documentation**: Examples for AWS S3, MinIO, LocalStack, and Cloudflare R2
+- **CHANGELOG.md**: Added for release tracking
+
+### Changed
+
+- **License**: Project is now licensed under Apache 2.0
+- **README**: Now lists supported backends and license
+
+### Fixed
+
+- N/A
+
+### Breaking Changes
+
+- None
+
+### Known Limitations
+
+- Single-writer semantics required (no concurrent writer conflict resolution)
+- Large uploads (>5GB on S3) have TOCTOU window for no-overwrite guarantee
+- Cleanup of partial objects is best-effort, not guaranteed
+
+### Upgrade Notes
+
+- S3 adapter moved from `internal/` to `lode/s3`; update import paths if using experimental adapter
+
+### References
+
+- [PUBLIC_API.md](PUBLIC_API.md) — S3 adapter documentation
+- [examples/s3_experimental/](examples/s3_experimental/) — S3 usage examples
+
+---
+
+## [0.1.0] - 2026-02-03
+
+### Added
+
+- **Public API**: Datasets and readers with immutable snapshots, manifests, and explicit metadata
+- **Layout System**: Default, Hive, and Flat layouts with dataset enumeration and partition-pruning
+- **Storage Adapters**: Filesystem (`NewFSFactory`) and in-memory (`NewMemoryFactory`)
+- **S3 Adapter**: Experimental adapter under `internal/` (promoted to public in v0.2.0)
+- **Codecs**: JSONL codec for structured records
+- **Compression**: Gzip compressor and no-op default
+- **Range Reads**: `ReadRange` and `ReaderAt` for partial object access
+- **Examples**: Default layout, Hive layout, manifest-driven discovery, blob upload, S3 experimental
+
+### Changed
+
+- N/A (initial release)
+
+### Fixed
+
+- N/A (initial release)
+
+### Breaking Changes
+
+- None (initial release)
+
+### Known Limitations
+
+1. **Single-writer only**: Concurrent writes to the same dataset may corrupt history
+2. **No query execution**: Lode structures data; query engines consume it
+3. **No background compaction**: Callers control snapshot lifecycle
+4. **No automatic cleanup**: Partial objects from failed writes may remain
+5. **Manifest-driven only**: Data files without manifests are not discovered
+
+### Upgrade Notes
+
+**Runtime Requirements:**
+- Go 1.25 or later
+
+**Storage:**
+- Filesystem paths must exist before use; Lode does not create directories
+- S3 buckets must exist before use; Lode does not create buckets
+
+### References
+
+- [PUBLIC_API.md](PUBLIC_API.md) — Public API documentation
+- [docs/contracts/](docs/contracts/) — Normative contract specifications
+- [examples/](examples/) — Runnable usage examples
+
+---
+
+[Unreleased]: https://github.com/justapithecus/lode/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/justapithecus/lode/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/justapithecus/lode/releases/tag/v0.1.0


### PR DESCRIPTION
- Add intro paragraph with Keep a Changelog and SemVer references
- Add [Unreleased] section with v0.3.0 placeholder
- Restructure v0.2.0 and v0.1.0 with standard headings: Added / Changed / Fixed / Breaking Changes / Known Limitations / Upgrade Notes / References
- Add footer links for version comparison URLs

Before/after section mapping:
- v0.2.0 bullet list → Added (S3, CHANGELOG) + Changed (License, README)
- v0.1.0 bullet list → Added (API, layouts, adapters, codecs, range reads, examples)
- v0.1.0 "Notable internal work" → removed (CI/tooling details not user-facing)

No semantic change to prior release claims; content reorganized only.