### PR TITLE
docs(snippets): 📝 define snippet policy and annotate code fences

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -30,6 +30,7 @@ Default bundle:
 - Checksum: none (opt-in)
 
 Example:
+<!-- illustrative -->
 ```go
 import (
     "github.com/justapithecus/lode/lode"
@@ -50,6 +51,7 @@ Default behavior:
 - Layout: DefaultLayout
 
 Example:
+<!-- illustrative -->
 ```go
 reader, _ := lode.NewReader(
     lode.NewFSFactory("/data"),
@@ -137,6 +139,7 @@ block-indexed logs, and partial artifact previews.
 Records can optionally implement the `Timestamped` interface to enable
 automatic min/max timestamp tracking in manifests:
 
+<!-- illustrative -->
 ```go
 type Timestamped interface {
     Timestamp() time.Time
@@ -148,6 +151,7 @@ When records implement this interface, `Dataset.Write` computes
 This enables time-range pruning by query engines.
 
 Example:
+<!-- illustrative -->
 ```go
 type Event struct {
     ID        string
@@ -303,6 +307,7 @@ missing objects. Error semantics are stable and documented.
 
 Use `errors.Is()` to check for sentinel errors:
 
+<!-- illustrative -->
 ```go
 snap, err := ds.Latest(ctx)
 if errors.Is(err, lode.ErrNoSnapshots) {
@@ -354,6 +359,7 @@ minimal while giving you full control over credentials, endpoints, and options.
 
 ### AWS S3
 
+<!-- illustrative -->
 ```go
 import (
     "github.com/aws/aws-sdk-go-v2/config"
@@ -373,6 +379,7 @@ store, _ := s3.New(client, s3.Config{
 
 ### LocalStack
 
+<!-- illustrative -->
 ```go
 import (
     "github.com/aws/aws-sdk-go-v2/aws"
@@ -399,6 +406,7 @@ store, _ := s3.New(client, s3.Config{Bucket: "my-bucket"})
 
 ### MinIO
 
+<!-- illustrative -->
 ```go
 cfg, _ := config.LoadDefaultConfig(ctx,
     config.WithRegion("us-east-1"),
@@ -416,6 +424,7 @@ store, _ := s3.New(client, s3.Config{Bucket: "my-bucket"})
 
 ### Cloudflare R2
 
+<!-- illustrative -->
 ```go
 cfg, _ := config.LoadDefaultConfig(ctx,
     config.WithRegion("auto"),

--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ If you know the snapshot ID, you know exactly what data you are reading.
 
 ### Install
 
+<!-- runnable -->
 ```bash
 go get github.com/justapithecus/lode
 ```
 
 ### Write and read a blob
 
+<!-- illustrative: shows API pattern; see examples/ for runnable code -->
 ```go
 package main
 
@@ -85,6 +87,7 @@ func main() {
 
 ### Write structured records
 
+<!-- illustrative: shows API pattern; see examples/ for runnable code -->
 ```go
 // With a codec, Write accepts structured data
 ds, _ := lode.NewDataset("events",
@@ -101,6 +104,7 @@ snap, _ := ds.Write(ctx, records, lode.Metadata{"batch": "1"})
 
 ### Stream large files
 
+<!-- illustrative: shows API pattern; see examples/ for runnable code -->
 ```go
 // StreamWrite is for large binary payloads (no codec)
 ds, _ := lode.NewDataset("backups", lode.NewFSFactory("/tmp/lode-demo"))

--- a/docs/SNIPPET_POLICY.md
+++ b/docs/SNIPPET_POLICY.md
@@ -1,0 +1,121 @@
+# SNIPPET_POLICY.md — Markdown Code Fence Conventions
+
+This document defines conventions for code snippets in Lode documentation.
+
+---
+
+## Snippet Categories
+
+### Runnable Snippets
+
+Snippets that can be executed directly or extracted and compiled.
+
+**Markers:**
+- Fenced with language identifier: ` ```go `, ` ```bash `
+- Contains complete, self-contained code OR references a runnable example
+- Annotated with `<!-- runnable -->` comment if verification is required
+
+**Requirements:**
+- Must compile (Go) or execute (bash) without modification
+- Import paths must be valid
+- No placeholder values (e.g., `...`, `<your-value>`)
+
+**Verification:**
+- CI job extracts and validates runnable snippets
+- Failures block merge
+
+### Illustrative Snippets
+
+Snippets that demonstrate API patterns but are not independently runnable.
+
+**Markers:**
+- Fenced with language identifier: ` ```go `, ` ```bash `
+- Annotated with `<!-- illustrative -->` comment
+- May contain:
+  - Partial code (no `package`/`func main()`)
+  - Elided imports or context
+  - Placeholder values (`...`, `// ...`)
+
+**Requirements:**
+- Must be syntactically plausible
+- Should align with actual API signatures
+- Not verified by CI
+
+---
+
+## Annotation Format
+
+Place HTML comments immediately before the code fence:
+
+```markdown
+<!-- illustrative -->
+```go
+ds, _ := lode.NewDataset("mydata", lode.NewFSFactory("/data"))
+```
+
+<!-- runnable -->
+```bash
+go get github.com/justapithecus/lode
+```
+```
+
+If no annotation is present, the snippet is assumed **illustrative** by default.
+
+---
+
+## File-Specific Conventions
+
+| File | Default | Notes |
+|------|---------|-------|
+| `README.md` | Illustrative | Quick Start snippets are illustrative patterns |
+| `PUBLIC_API.md` | Illustrative | API examples are patterns, not runnable programs |
+| `examples/*/README.md` | Illustrative | Prose guidance; runnable code is in `main.go` |
+| `examples/*/main.go` | Runnable | Full programs; verified by `task examples` |
+
+---
+
+## Inventory
+
+### README.md
+
+| Lines | Language | Category | Description |
+|-------|----------|----------|-------------|
+| 55-57 | bash | Runnable | `go get` install command |
+| 61-84 | go | Illustrative | Write and read blob pattern |
+| 88-100 | go | Illustrative | Write structured records pattern |
+| 104-111 | go | Illustrative | StreamWrite pattern |
+
+### PUBLIC_API.md
+
+| Lines | Language | Category | Description |
+|-------|----------|----------|-------------|
+| 33-43 | go | Illustrative | NewDataset construction |
+| 53-62 | go | Illustrative | NewReader construction |
+| 140-144 | go | Illustrative | Timestamped interface definition |
+| 151-162 | go | Illustrative | Timestamped implementation example |
+| 306-311 | go | Illustrative | errors.Is usage pattern |
+| 357-372 | go | Illustrative | AWS S3 client setup |
+| 376-398 | go | Illustrative | LocalStack client setup |
+| 402-415 | go | Illustrative | MinIO client setup |
+| 419-431 | go | Illustrative | Cloudflare R2 client setup |
+
+### examples/blob_upload/README.md
+
+No code fences.
+
+---
+
+## Maintenance
+
+When adding new snippets:
+1. Determine if the snippet is runnable or illustrative
+2. Add the appropriate annotation comment
+3. Update the inventory table in this document
+4. If runnable, ensure CI verification passes
+
+---
+
+## References
+
+- Runnable examples: `examples/*/main.go` (verified by `task examples`)
+- Contract specifications: `docs/contracts/`


### PR DESCRIPTION
## PR 8 — Snippet Policy (Docs Contract)

**Goal**: Define runnable vs illustrative Markdown snippets.

### Changes

- **New**: `docs/SNIPPET_POLICY.md` — snippet conventions and inventory
- **Updated**: `README.md` — annotated 4 code fences (1 runnable, 3 illustrative)
- **Updated**: `PUBLIC_API.md` — annotated 9 code fences (all illustrative)

### Snippet Categories

| Category | Marker | CI Verified | Count |
|----------|--------|-------------|-------|
| Runnable | `<!-- runnable -->` | Yes (future PR 9) | 1 |
| Illustrative | `<!-- illustrative -->` | No | 12 |

### Inventory

See `docs/SNIPPET_POLICY.md` for full inventory table.

### Acceptance Criteria

- [x] Clear marking rules for runnable snippets
- [x] Explicit exclusions for illustrative snippets
- [x] No contract contradictions
- [x] Inventory table: all code fences + status

### Tests/Evidence

- [x] `task test` — sanity pass

### Out of Scope

- CI/tooling automation (PR 9)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)