### PR TITLE
fix(docs): 🐛 correct API signatures and improve snippet verifier portability

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -258,7 +258,7 @@ If provisioning helpers are needed, implement them outside Lode's core APIs:
 <!-- illustrative -->
 ```go
 // Wrapper that ensures storage exists before constructing dataset
-func EnsureFSDataset(id, root string, opts ...lode.Option) (*lode.Dataset, error) {
+func EnsureFSDataset(id, root string, opts ...lode.Option) (lode.Dataset, error) {
     if err := os.MkdirAll(root, 0755); err != nil {
         return nil, fmt.Errorf("create storage root: %w", err)
     }

--- a/README.md
+++ b/README.md
@@ -247,9 +247,10 @@ aws s3 mb s3://my-bucket
 
 <!-- illustrative -->
 ```go
-// Then construct dataset
+// Then construct dataset (wrap Store in factory)
 store, err := s3.New(client, s3.Config{Bucket: "my-bucket"})
-ds, err := lode.NewDataset("events", store)
+factory := func() (lode.Store, error) { return store, nil }
+ds, err := lode.NewDataset("events", factory)
 ```
 
 ### Bootstrap Helpers
@@ -259,7 +260,7 @@ If you need provisioning helpers, implement them outside core APIs:
 <!-- illustrative -->
 ```go
 // Example: ensure directory exists before constructing dataset
-func EnsureFSDataset(id, root string, opts ...lode.Option) (*lode.Dataset, error) {
+func EnsureFSDataset(id, root string, opts ...lode.Option) (lode.Dataset, error) {
     if err := os.MkdirAll(root, 0755); err != nil {
         return nil, fmt.Errorf("create storage root: %w", err)
     }


### PR DESCRIPTION
## Fix PR — Address Review Findings

Fixes issues identified in PR 8-11 review.

### High Severity Fixes

1. **EnsureFSDataset return type** (README.md, PUBLIC_API.md)
   - Changed `*lode.Dataset` → `lode.Dataset` (interface, not pointer)
   - `NewDataset` returns interface, not pointer

2. **S3 bootstrap example** (README.md)
   - `s3.New` returns `*Store`, not `StoreFactory`
   - Now correctly wraps Store in factory function

### Medium Severity Fixes

3. **Snippet verifier portability** (scripts/verify-snippets.sh)
   - Replaced `base64 -w0` (GNU-only) with `base64 | tr -d '\n'`
   - Added fallback: tries `-d` (GNU) then `-D` (BSD/macOS) for decode

### Tests/Evidence

- [x] `task lint` — pass
- [x] `task test` — pass
- [x] `task snippets` — pass

### Not Addressed (Acknowledged)

- **Go snippet false positives**: Injected imports can mask incomplete snippets. Accepted trade-off for now; all current runnable snippets are bash.
- **PR 11 commit visibility claim**: Example demonstrates happy path; pre-commit invisibility is hard to show with this API. Will soften claim in PR 11 README.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)