### PR TITLE
docs(streaming): 📝 add StreamWriteRecords failure-mode guidance

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -216,12 +216,13 @@ Common errors when using streaming APIs:
 | `ErrCodecNotStreamable` | `StreamWriteRecords` | Codec doesn't support streaming | Use streaming codec (JSONL) or `Write` |
 | `ErrNilIterator` | `StreamWriteRecords` | Iterator is nil | Provide valid `RecordIterator` |
 | `ErrPartitioningNotSupported` | `StreamWriteRecords` | Partitioning configured | Use `Write` for partitioned data |
-| `metadata is nil` | Both | Nil metadata passed | Use `lode.Metadata{}` for empty |
+| "metadata must be non-nil" | Both | Nil metadata passed | Use `lode.Metadata{}` for empty |
 
 **On failure:**
 - No manifest is written (snapshot does not exist)
 - Partial data may remain in storage (best-effort cleanup)
-- Use `errors.Is()` to check for specific sentinel errors
+- Use `errors.Is()` to check sentinel errors (`ErrCodec*`, `ErrNil*`, `ErrPartitioning*`)
+- Note: metadata error is not a sentinel; check with `strings.Contains()` or handle as configuration error
 
 *Contract reference: [`CONTRACT_ERRORS.md`](docs/contracts/CONTRACT_ERRORS.md)*
 

--- a/examples/stream_write_records/README.md
+++ b/examples/stream_write_records/README.md
@@ -28,14 +28,20 @@ Do NOT use `StreamWriteRecords` when:
 ## Failure Modes
 
 `StreamWriteRecords` validates configuration and input before streaming begins.
-Use `errors.Is()` to check for specific failures:
+
+**Sentinel errors** (use `errors.Is()` to check):
 
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `ErrNilIterator` | Passed `nil` as iterator | Provide a valid `RecordIterator` |
 | `ErrCodecNotStreamable` | Codec doesn't support streaming | Use a streaming codec (e.g., JSONL) or use `Write` |
 | `ErrPartitioningNotSupported` | Dataset has partitioning configured | Use `Write` for partitioned data |
-| `metadata is nil` | Passed `nil` metadata | Use `lode.Metadata{}` for empty metadata |
+
+**Configuration errors** (not sentinels):
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| "metadata must be non-nil" | Passed `nil` metadata | Use `lode.Metadata{}` for empty metadata |
 
 ### Iterator Errors
 


### PR DESCRIPTION
## PR 12 — Streaming Failure-Mode Examples

**Goal**: Complete deferred failure-mode guidance for streaming.

### Changes

- **Updated**: `examples/stream_write_records/README.md` — failure modes section
- **Updated**: `PUBLIC_API.md` — streaming troubleshooting section

### Failure Modes Covered

| Error | Cause | Documented |
|-------|-------|------------|
| `ErrNilIterator` | Nil iterator passed | ✅ |
| `ErrCodecNotStreamable` | Non-streaming codec | ✅ |
| `ErrPartitioningNotSupported` | Partitioning configured | ✅ |
| `ErrCodecConfigured` | Codec with StreamWrite | ✅ |
| `metadata is nil` | Nil metadata | ✅ |
| Iterator error | `iterator.Err()` non-nil | ✅ |
| Abort semantics | Implicit on error | ✅ |

### Acceptance Criteria

- [x] Every failure mode maps to `CONTRACT_ERRORS.md` and `CONTRACT_WRITE_API.md`
- [x] No unverifiable semantics claims
- [x] Snippet policy markers remain valid

### Tests/Evidence

- [x] `task test` — pass
- [x] `task examples` — pass (5/5)
- [x] `task snippets` — pass

### Out of Scope

- Runtime behavior changes
- New sentinels
- API surface changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)