### PR TITLE
feat(compressor): ✨ add zstd compressor implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/smithy-go v1.24.0
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.18.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=

--- a/lode/compress.go
+++ b/lode/compress.go
@@ -3,6 +3,8 @@ package lode
 import (
 	"compress/gzip"
 	"io"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 // -----------------------------------------------------------------------------
@@ -33,6 +35,41 @@ func (g *gzipCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
 
 func (g *gzipCompressor) Decompress(r io.Reader) (io.ReadCloser, error) {
 	return gzip.NewReader(r)
+}
+
+// -----------------------------------------------------------------------------
+// Zstd Compressor
+// -----------------------------------------------------------------------------
+
+// zstdCompressor implements Compressor using zstd compression.
+type zstdCompressor struct{}
+
+// NewZstdCompressor creates a zstd compressor.
+//
+// Files are compressed using Zstandard format with .zst extension.
+// Zstd provides higher compression ratios and faster decompression than gzip.
+func NewZstdCompressor() Compressor {
+	return &zstdCompressor{}
+}
+
+func (z *zstdCompressor) Name() string {
+	return "zstd"
+}
+
+func (z *zstdCompressor) Extension() string {
+	return ".zst"
+}
+
+func (z *zstdCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return zstd.NewWriter(w)
+}
+
+func (z *zstdCompressor) Decompress(r io.Reader) (io.ReadCloser, error) {
+	decoder, err := zstd.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return decoder.IOReadCloser(), nil
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `NewZstdCompressor()` using the `klauspost/compress/zstd` library
- Implements `Compressor` interface: `Name()="zstd"`, `Extension()=".zst"`
- Add comprehensive tests for Write, StreamWrite, and StreamWriteRecords paths
- All tests verify manifest recording and file extension correctness

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — all tests pass including new zstd tests
- [x] `task build` — builds successfully
- [x] `task examples` — all examples run successfully

## PR 15 of Milestone C (Zstd)

Completes the zstd compressor implementation. Next PR (16) will promote the "planned" docs to active API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)