### PR TITLE
docs(api): 📝 promote zstd compressor to active API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- N/A
+- **Zstd Compressor**: `NewZstdCompressor()` for higher compression ratio and faster decompression than gzip
 
 ### Changed
 
-- **Zstd Compressor Docs Prep**: Selection guidance and planned API documented (implementation in next PR)
+- N/A
 
 ### Fixed
 

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -107,8 +107,7 @@ includes a curated set of components:
 **Compressors:**
 - `NewNoOpCompressor()` - No compression (default)
 - `NewGzipCompressor()` - Gzip compression
-
-*Planned: `NewZstdCompressor()` for higher compression ratio and faster decompression.*
+- `NewZstdCompressor()` - Zstd compression (higher ratio, faster decompression)
 
 **Codecs:**
 - `NewJSONLCodec()` - JSON Lines format
@@ -261,7 +260,7 @@ Common errors when using streaming APIs:
 |------------|----------|------------|
 | `NewNoOpCompressor()` | Data is already compressed, or compression overhead not justified | No CPU cost; no size reduction |
 | `NewGzipCompressor()` | Broad compatibility required (gzip is universal) | Good ratio; moderate speed |
-| `NewZstdCompressor()` *(planned)* | Best compression ratio or fast decompression needed | Better ratio than gzip; faster decompression |
+| `NewZstdCompressor()` | Best compression ratio or fast decompression needed | Better ratio than gzip; faster decompression |
 
 **Notes:**
 - Compressor choice is recorded in manifests; readers must support the compressor used


### PR DESCRIPTION
## Summary

- Remove "(planned)" markers from PUBLIC_API.md zstd documentation
- Add `NewZstdCompressor()` to active compressor constructor list
- Update CHANGELOG to reflect zstd as an added feature (not docs prep)

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — all tests pass
- [x] `task build` — successful

## PR 16 of Milestone C (Zstd)

Completes the zstd compressor documentation integration. Milestone C is now complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)