### PR TITLE
docs(contracts): 📝 add canonical example and API convention contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,20 @@ Assume it is invalid and stop.
 
 ---
 
+## API and example conventions
+
+- `PUBLIC_API.md` is canonical for callsite conventions
+- Example code must not drift from `PUBLIC_API.md`
+- Write examples prefer `lode.R(...)` for inline record construction
+- `[]lode.D` is allowed only when backing an iterator (add comment explaining why)
+- Pre-v1 ergonomics changes require contract+docs+tests+examples updated together
+
+If examples diverge from these conventions, stop and ask before editing.
+
+See `docs/contracts/CONTRACT_EXAMPLES.md` for full normative specification.
+
+---
+
 ## Priority order
 
 1. Correctness

--- a/docs/ARCH_INDEX.md
+++ b/docs/ARCH_INDEX.md
@@ -38,6 +38,7 @@ Plans, contracts, and research notes. Contracts define **system behavior**.
 - `contracts/CONTRACT_READ_API.md` — read API contract and adapter obligations
 - `contracts/CONTRACT_ERRORS.md` — error taxonomy and handling guidelines
 - `contracts/CONTRACT_TEST_MATRIX.md` — contract-to-test traceability and coverage gaps
+- `contracts/CONTRACT_EXAMPLES.md` — example and callsite conventions
 
 Contracts are authoritative over code.
 

--- a/docs/contracts/CONTRACT_EXAMPLES.md
+++ b/docs/contracts/CONTRACT_EXAMPLES.md
@@ -1,0 +1,96 @@
+# CONTRACT_EXAMPLES.md — Example and Callsite Conventions
+
+This contract defines normative conventions for examples and API callsites in Lode.
+
+---
+
+## Authority
+
+- `PUBLIC_API.md` is canonical for callsite conventions and API signatures.
+- Example code must not drift from `PUBLIC_API.md`.
+- If examples and `PUBLIC_API.md` conflict, `PUBLIC_API.md` is authoritative.
+
+---
+
+## Record Construction Conventions
+
+### Preferred: `lode.R(...)`
+
+Use `lode.R(...)` for Write examples with inline record literals:
+
+```go
+records := lode.R(
+    lode.D{"id": "1", "name": "alice"},
+    lode.D{"id": "2", "name": "bob"},
+)
+snap, err := ds.Write(ctx, records, lode.Metadata{})
+```
+
+**Why:** `R(...)` is ergonomic, reads naturally, and builds `[]any` directly.
+
+### Allowed: `[]lode.D` for Iterator Backing
+
+Use `[]lode.D` only when the slice backs a `RecordIterator`:
+
+```go
+// []lode.D is appropriate here: it backs the iterator
+records := []lode.D{
+    {"id": "1", "name": "alice"},
+    {"id": "2", "name": "bob"},
+}
+iter := NewSliceIterator(records)
+snap, err := ds.StreamWriteRecords(ctx, lode.Metadata{}, iter)
+```
+
+When using `[]lode.D`, add a brief comment explaining the iterator backing relationship.
+
+### Raw Blobs
+
+For raw blob writes (no codec), use `[]any{blobData}`:
+
+```go
+snap, err := ds.Write(ctx, []any{blobData}, lode.Metadata{})
+```
+
+---
+
+## Variable Naming Conventions
+
+| Variable | Purpose |
+|----------|---------|
+| `records` | Slice of records for Write or iterator backing |
+| `iter` | RecordIterator instance |
+| `metadata` | Metadata map (`lode.Metadata{}`) |
+| `snap` | Snapshot result from write operations |
+| `ds` | Dataset instance |
+| `ctx` | Context |
+
+---
+
+## Pre-v1 Ergonomics Changes
+
+Pre-v1 ergonomics changes (e.g., parameter reordering) are allowed only when:
+
+1. Contract is updated in the same PR as the behavior change
+2. `PUBLIC_API.md` is updated
+3. All tests are updated
+4. All examples are updated
+5. CHANGELOG includes migration note
+
+No mixed old/new callsites may exist after the change.
+
+---
+
+## Agent Behavior
+
+Agents must:
+- Stop and ask if an example diverges from `PUBLIC_API.md` conventions
+- Stop and ask before introducing new callsite patterns not covered here
+- Prefer editing existing examples over creating new ones
+
+---
+
+## References
+
+- [`PUBLIC_API.md`](../../PUBLIC_API.md) — Canonical API documentation
+- [`CONTRACT_WRITE_API.md`](CONTRACT_WRITE_API.md) — Write API semantics


### PR DESCRIPTION
## Summary

- Add `docs/contracts/CONTRACT_EXAMPLES.md` with normative callsite conventions
- Update `AGENTS.md` with API/example convention rules and stop triggers
- Update `docs/ARCH_INDEX.md` with navigation entry for new contract

## Establishes

- `PUBLIC_API.md` is canonical for callsite conventions
- `lode.R(...)` preferred for Write examples
- `[]lode.D` allowed only when backing iterators (with comment)
- Pre-v1 ergonomics changes require contract+docs+tests+examples updated together
- Agent "stop and ask" trigger when examples diverge from conventions

## Test plan

- [x] `task test` — all tests pass
- [x] `task snippets` — all snippets valid

## PR 14 of v0.4.0 Ergonomics Cleanup

Convention authority anchor. Next PR (15) will apply StreamWriteRecords ergonomics change if approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)