### PR TITLE
refactor(api): ♻️ reorder StreamWriteRecords args for callsite ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- N/A
+- **StreamWriteRecords Parameter Order**: Reordered from `(ctx, metadata, records)` to `(ctx, records, metadata)` for ergonomic consistency with iterator-first patterns
 
 ### Fixed
 
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- None
+- **StreamWriteRecords Signature**: Parameter order changed from `StreamWriteRecords(ctx, metadata, records)` to `StreamWriteRecords(ctx, records, metadata)`. Update callsites accordingly.
 
 ### Known Limitations
 
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrade Notes
 
-- N/A
+- **StreamWriteRecords migration**: Update all `StreamWriteRecords` callsites to use the new parameter order: `ds.StreamWriteRecords(ctx, iter, metadata)` instead of `ds.StreamWriteRecords(ctx, metadata, iter)`
 
 ### References
 

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -189,7 +189,7 @@ streaming writes of a single binary payload. `StreamWriter.Write` streams bytes,
 If `Close` is called before `Commit`, the stream is aborted and no snapshot is created.
 Streamed writes are raw-blob only: codecs are not applied and row count is `1`.
 
-`Dataset.StreamWriteRecords(ctx, metadata, records)` consumes a pull-based iterator
+`Dataset.StreamWriteRecords(ctx, records, metadata)` consumes a pull-based iterator
 of records and streams them through a streaming-capable codec. If the configured
 codec does not support streaming, `StreamWriteRecords` returns an error.
 

--- a/docs/contracts/CONTRACT_EXAMPLES.md
+++ b/docs/contracts/CONTRACT_EXAMPLES.md
@@ -39,7 +39,7 @@ records := []lode.D{
     {"id": "2", "name": "bob"},
 }
 iter := NewSliceIterator(records)
-snap, err := ds.StreamWriteRecords(ctx, lode.Metadata{}, iter)
+snap, err := ds.StreamWriteRecords(ctx, iter, lode.Metadata{})
 ```
 
 When using `[]lode.D`, add a brief comment explaining the iterator backing relationship.

--- a/docs/contracts/CONTRACT_WRITE_API.md
+++ b/docs/contracts/CONTRACT_WRITE_API.md
@@ -53,7 +53,7 @@ It is authoritative for any `Dataset` implementation.
 
 ### StreamWriteRecords Semantics
 
-- `StreamWriteRecords(ctx, metadata, records)` MUST return an error if metadata is nil.
+- `StreamWriteRecords(ctx, records, metadata)` MUST return an error if metadata is nil.
 - `StreamWriteRecords` MUST return an error if records iterator is nil.
 - `StreamWriteRecords` MUST consume records via a pull-based iterator.
 - `StreamWriteRecords` MUST return an error if the configured codec does not support

--- a/examples/stream_write_records/main.go
+++ b/examples/stream_write_records/main.go
@@ -82,10 +82,10 @@ func run() error {
 	// - Encodes through codec directly to storage
 	// - Writes manifest only after all records are processed
 	// - Returns error if iterator fails
-	snap, err := ds.StreamWriteRecords(ctx, lode.Metadata{
+	snap, err := ds.StreamWriteRecords(ctx, iter, lode.Metadata{
 		"source":      "stream_write_records_example",
 		"record_type": "user_events",
-	}, iter)
+	})
 	if err != nil {
 		return fmt.Errorf("stream write records: %w", err)
 	}

--- a/lode/api.go
+++ b/lode/api.go
@@ -292,7 +292,7 @@ type Dataset interface {
 	// StreamWriteRecords consumes records via a pull-based iterator and streams them
 	// through a streaming-capable codec. Returns an error if metadata is nil or if
 	// the configured codec does not support streaming.
-	StreamWriteRecords(ctx context.Context, metadata Metadata, records RecordIterator) (*Snapshot, error)
+	StreamWriteRecords(ctx context.Context, records RecordIterator, metadata Metadata) (*Snapshot, error)
 }
 
 // -----------------------------------------------------------------------------

--- a/lode/dataset.go
+++ b/lode/dataset.go
@@ -511,7 +511,7 @@ func (d *dataset) StreamWrite(ctx context.Context, metadata Metadata) (StreamWri
 	}, nil
 }
 
-func (d *dataset) StreamWriteRecords(ctx context.Context, metadata Metadata, records RecordIterator) (*Snapshot, error) {
+func (d *dataset) StreamWriteRecords(ctx context.Context, records RecordIterator, metadata Metadata) (*Snapshot, error) {
 	if metadata == nil {
 		return nil, errors.New("lode: metadata must be non-nil (use empty map {} for no metadata)")
 	}

--- a/lode/dataset_test.go
+++ b/lode/dataset_test.go
@@ -312,7 +312,7 @@ func TestDataset_StreamWriteRecords_EmptyMetadata_ValidAndPersisted(t *testing.T
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1"}}}
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatalf("expected empty metadata to be valid, got error: %v", err)
 	}
@@ -641,7 +641,7 @@ func TestDataset_StreamWriteRecords_ManifestPresenceIsCommitSignal(t *testing.T)
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1"}, D{"id": "2"}}}
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,7 +674,7 @@ func TestDataset_StreamWriteRecords_IteratorError_NoManifestWritten(t *testing.T
 	iterErr := errors.New("iterator failure")
 	iter := &errorIterator{err: iterErr}
 
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err == nil {
 		t.Fatal("expected error from iterator, got nil")
 	}
@@ -1275,7 +1275,7 @@ func TestDataset_StreamWriteRecords_WithZstdCompression(t *testing.T) {
 	}
 	iter := &sliceIterator{records: records}
 
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatalf("StreamWriteRecords failed: %v", err)
 	}
@@ -1358,7 +1358,7 @@ func TestDataset_StreamWriteRecords_Success(t *testing.T) {
 	}
 	iter := &sliceIterator{records: records}
 
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{"source": "stream"}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{"source": "stream"})
 	if err != nil {
 		t.Fatalf("StreamWriteRecords failed: %v", err)
 	}
@@ -1403,7 +1403,7 @@ func TestDataset_StreamWriteRecords_NonStreamingCodec_ReturnsError(t *testing.T)
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1"}}}
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if !errors.Is(err, ErrCodecNotStreamable) {
 		t.Errorf("expected ErrCodecNotStreamable, got: %v", err)
 	}
@@ -1416,7 +1416,7 @@ func TestDataset_StreamWriteRecords_NoCodec_ReturnsError(t *testing.T) {
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1"}}}
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err == nil {
 		t.Fatal("expected error for no codec, got nil")
 	}
@@ -1432,7 +1432,7 @@ func TestDataset_StreamWriteRecords_NilMetadata_ReturnsError(t *testing.T) {
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1"}}}
-	_, err = ds.StreamWriteRecords(t.Context(), nil, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, nil)
 	if err == nil {
 		t.Fatal("expected error for nil metadata, got nil")
 	}
@@ -1447,7 +1447,7 @@ func TestDataset_StreamWriteRecords_NilIterator_ReturnsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, nil)
+	_, err = ds.StreamWriteRecords(t.Context(), nil, Metadata{})
 	if err == nil {
 		t.Fatal("expected error for nil iterator, got nil")
 	}
@@ -1466,7 +1466,7 @@ func TestDataset_StreamWriteRecords_WithPartitioner_ReturnsError(t *testing.T) {
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1", "day": "2024-01-01"}}}
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err == nil {
 		t.Fatal("expected error for partitioning, got nil")
 	}
@@ -1492,7 +1492,7 @@ func TestDataset_StreamWriteRecords_TimestampedRecords_ComputesMinMax(t *testing
 	}
 	iter := &sliceIterator{records: records}
 
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1523,7 +1523,7 @@ func TestDataset_StreamWriteRecords_NonTimestampedRecords_OmitsMinMax(t *testing
 	}
 	iter := &sliceIterator{records: records}
 
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1544,7 +1544,7 @@ func TestDataset_StreamWriteRecords_EmptyIterator(t *testing.T) {
 
 	iter := &sliceIterator{records: []any{}}
 
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatalf("StreamWriteRecords failed: %v", err)
 	}
@@ -1563,7 +1563,7 @@ func TestDataset_StreamWriteRecords_IteratorError(t *testing.T) {
 	iterErr := errors.New("iterator failure")
 	iter := &errorIterator{err: iterErr}
 
-	_, err = ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	_, err = ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err == nil {
 		t.Fatal("expected error from iterator, got nil")
 	}
@@ -1592,7 +1592,7 @@ func TestDataset_StreamWriteRecords_WithCompression(t *testing.T) {
 	}
 	iter := &sliceIterator{records: records}
 
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatalf("StreamWriteRecords failed: %v", err)
 	}
@@ -1628,7 +1628,7 @@ func TestDataset_StreamWriteRecords_ParentSnapshotLinked(t *testing.T) {
 
 	// Second write (StreamWriteRecords)
 	iter := &sliceIterator{records: []any{D{"id": "2"}}}
-	secondSnap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	secondSnap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1737,7 +1737,7 @@ func TestDataset_StreamWriteRecords_WithChecksum_RecordsChecksum(t *testing.T) {
 	}
 
 	iter := &sliceIterator{records: []any{D{"id": "1"}, D{"id": "2"}}}
-	snap, err := ds.StreamWriteRecords(t.Context(), Metadata{}, iter)
+	snap, err := ds.StreamWriteRecords(t.Context(), iter, Metadata{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Change `StreamWriteRecords` parameter order from `(ctx, metadata, records)` to `(ctx, records, metadata)` for ergonomic consistency with iterator-first patterns.

## Changes

- `lode/api.go` — Interface signature
- `lode/dataset.go` — Implementation
- `lode/dataset_test.go` — All test callsites (17 occurrences)
- `examples/stream_write_records/main.go` — Example
- `PUBLIC_API.md` — Documentation
- `docs/contracts/CONTRACT_WRITE_API.md` — Contract
- `docs/contracts/CONTRACT_EXAMPLES.md` — Example convention
- `CHANGELOG.md` — Migration note

## Breaking Change

```go
// Before
snap, err := ds.StreamWriteRecords(ctx, metadata, iter)

// After
snap, err := ds.StreamWriteRecords(ctx, iter, metadata)
```

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — all tests pass
- [x] `task build` — successful
- [x] `task examples` — all examples run
- [x] `task snippets` — all snippets valid

## PR 15 of v0.4.0 Ergonomics Cleanup

Per CONTRACT_EXAMPLES.md: pre-v1 ergonomics changes require contract+docs+tests+examples updated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)