### PR TITLE
docs(examples): 📝 normalize example conventions and record construction

### DIFF
--- a/docs/contracts/CONTRACT_EXAMPLES.md
+++ b/docs/contracts/CONTRACT_EXAMPLES.md
@@ -23,7 +23,7 @@ records := lode.R(
     lode.D{"id": "1", "name": "alice"},
     lode.D{"id": "2", "name": "bob"},
 )
-snap, err := ds.Write(ctx, records, lode.Metadata{})
+snapshot, err := ds.Write(ctx, records, lode.Metadata{})
 ```
 
 **Why:** `R(...)` is ergonomic, reads naturally, and builds `[]any` directly.
@@ -39,7 +39,7 @@ records := []lode.D{
     {"id": "2", "name": "bob"},
 }
 iter := NewSliceIterator(records)
-snap, err := ds.StreamWriteRecords(ctx, iter, lode.Metadata{})
+snapshot, err := ds.StreamWriteRecords(ctx, iter, lode.Metadata{})
 ```
 
 When using `[]lode.D`, add a brief comment explaining the iterator backing relationship.
@@ -49,7 +49,7 @@ When using `[]lode.D`, add a brief comment explaining the iterator backing relat
 For raw blob writes (no codec), use `[]any{blobData}`:
 
 ```go
-snap, err := ds.Write(ctx, []any{blobData}, lode.Metadata{})
+snapshot, err := ds.Write(ctx, []any{blobData}, lode.Metadata{})
 ```
 
 ---
@@ -61,7 +61,7 @@ snap, err := ds.Write(ctx, []any{blobData}, lode.Metadata{})
 | `records` | Slice of records for Write or iterator backing |
 | `iter` | RecordIterator instance |
 | `metadata` | Metadata map (`lode.Metadata{}`) |
-| `snap` | Snapshot result from write operations |
+| `snapshot` | Snapshot result from write operations |
 | `ds` | Dataset instance |
 | `ctx` | Context |
 


### PR DESCRIPTION
## Summary

- Add comment in `stream_write_records` explaining `[]lode.D` iterator backing per CONTRACT_EXAMPLES.md
- Normalize snapshot variable naming: `snap` → `snapshot` to match 4/5 existing examples
- Update CONTRACT_EXAMPLES.md convention table and code examples to use `snapshot`

## Changes

- `examples/stream_write_records/main.go` — Add convention comment, rename `snap` to `snapshot`
- `docs/contracts/CONTRACT_EXAMPLES.md` — Update variable naming convention and code examples

## Test plan

- [x] `task test` — all tests pass
- [x] `task examples` — all examples run
- [x] `task snippets` — all snippets valid

## PR 16 of v0.4.0 Ergonomics Cleanup

No functional changes. Convention alignment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)