### PR TITLE
docs(s3): 📝 add backend compatibility matrix for conditional multipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- N/A
+- **S3 Backend Compatibility Matrix**: Added documentation for conditional multipart completion support across S3-compatible backends; verified on AWS S3, untested on MinIO/LocalStack/R2
 
 ### Fixed
 
 - **S3 Multipart Atomic No-Overwrite**: Large uploads (>5GB) now use conditional completion (`If-None-Match` on `CompleteMultipartUpload`) for atomic no-overwrite guarantee, closing the TOCTOU window that existed in v0.2.0
+
+### Known Limitations
+
+- **S3-compatible backend caveat**: Atomic no-overwrite for large uploads (>5GB) is verified on AWS S3; assumed but untested for other S3-compatible backends (MinIO, LocalStack, R2). If your backend does not support `If-None-Match` on `CompleteMultipartUpload`, large uploads may fail or lose atomicity. See `lode/s3` package docs for the backend support matrix.
 
 ### Breaking Changes
 

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -341,7 +341,7 @@ External coordination (locks, queues, leader election) is the caller's responsib
 ### Large Upload Guarantees
 
 For uploads exceeding the storage adapter's atomic threshold (e.g., 5GB for S3),
-the S3 adapter now uses conditional completion (`If-None-Match` on `CompleteMultipartUpload`)
+the S3 adapter uses conditional completion (`If-None-Match` on `CompleteMultipartUpload`)
 to provide the same atomic no-overwrite guarantee as small uploads.
 
 Both upload paths now provide atomic no-overwrite guarantees:
@@ -350,6 +350,22 @@ Both upload paths now provide atomic no-overwrite guarantees:
 
 Preflight existence checks are retained as a fail-fast optimization to avoid
 uploading parts for objects that already exist.
+
+**Backend Compatibility Caveat:**
+
+The atomic guarantee for large uploads (>5GB) depends on backend support for
+`If-None-Match` on `CompleteMultipartUpload`. This has been verified on AWS S3
+but is assumed (untested) for other S3-compatible backends:
+
+| Backend | Conditional Multipart | Status |
+|---------|----------------------|--------|
+| AWS S3 | Supported | ✅ Verified |
+| MinIO | Unknown | ⚠️ Untested |
+| LocalStack | Unknown | ⚠️ Untested |
+| Cloudflare R2 | Unknown | ⚠️ Untested |
+
+If using an untested backend with large uploads: either verify support experimentally,
+or ensure single-writer semantics at the application level.
 
 *Contract reference: [`CONTRACT_STORAGE.md`](docs/contracts/CONTRACT_STORAGE.md) §Put Upload Paths, [`CONTRACT_WRITE_API.md`](docs/contracts/CONTRACT_WRITE_API.md) §Storage-Level Concurrency*
 


### PR DESCRIPTION
## Summary

Document that conditional multipart completion (`If-None-Match` on `CompleteMultipartUpload`) is verified on AWS S3 but untested on other S3-compatible backends.

## Changes

### 1. Backend support matrix in `lode/s3/store.go` package docs

```
| Backend       | Conditional Completion | Status      |
|---------------|------------------------|-------------|
| AWS S3        | Supported              | ✅ Verified  |
| MinIO         | Unknown                | ⚠️ Untested  |
| LocalStack    | Unknown                | ⚠️ Untested  |
| Cloudflare R2 | Unknown                | ⚠️ Untested  |
```

### 2. `PUBLIC_API.md` caveat

Added backend compatibility table with guidance for untested backends.

### 3. `lode/s3/store.go` code comment

Added inline comment at `CompleteMultipartUpload` call noting the assumption and pointing to package docs.

### 4. `CHANGELOG.md` updates

- **Changed**: Added entry for backend compatibility matrix
- **Known Limitations**: Added caveat about untested S3-compatible backends

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)