### PR TITLE
docs(agents): 📝 add Go code style section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,14 @@ Assume it is invalid and stop.
 
 ---
 
+## Go code style
+
+- Prefer `any` over `interface{}`
+- Exceptions: When implementing interfaces from external packages that use `interface{}`
+- Use `//nolint:` comments with explanation when suppressing linters
+
+---
+
 ## Declarative style (critical)
 
 Code in this repository should prefer declarative patterns over imperative control flow.


### PR DESCRIPTION
## Summary

- Added **Go code style** section to AGENTS.md
- Prefer `any` over `interface{}`
- Document exception for external interface compatibility
- Require explanation for `//nolint:` suppressions

## Notes

Also assessed parquet codec for table-driven refactoring (per PR D plan). Concluded the existing structure is appropriate:

- `convertToParquetValue` has inherent complexity from type-specific validation (overflow checks, truncation detection, timestamp parsing)
- The `//nolint:gocyclo` is justified
- Forcing table-driven patterns would add abstraction without improving clarity

## Test plan

- [ ] Verify AGENTS.md renders correctly
- [ ] Confirm no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)