### PR TITLE
refactor(parquet): ♻️ extract validateSchema and use field lookup map

### DIFF
--- a/lode/codec_parquet.go
+++ b/lode/codec_parquet.go
@@ -87,6 +87,10 @@ type parquetCodec struct {
 
 // validateSchema validates a ParquetSchema and builds a field lookup map.
 // Returns an error if the schema contains invalid types, empty names, or duplicates.
+//
+// Contract: On success, the returned map contains an entry for every field in
+// schema.Fields. This guarantees that all fieldOrder entries (derived from
+// schema.Fields) will be present in fieldsByName.
 func validateSchema(schema ParquetSchema) (map[string]ParquetField, error) {
 	fieldsByName := make(map[string]ParquetField, len(schema.Fields))
 	for _, field := range schema.Fields {
@@ -242,8 +246,7 @@ func (c *parquetCodec) getCompressionOption() parquet.WriterOption {
 }
 
 // getFieldByName returns the ParquetField for a given field name.
-// Returns zero-value ParquetField if name is not found; schema validation
-// during construction guarantees all fieldOrder entries exist in the map.
+// Schema validation guarantees presence; missing key returns zero value (programmer error).
 func (c *parquetCodec) getFieldByName(name string) ParquetField {
 	return c.fieldsByName[name]
 }


### PR DESCRIPTION
## Summary

- Extract `validateSchema` helper for single-purpose schema validation
- Pre-compute `fieldsByName` map during construction
- Simplify `getFieldByName` from O(n) linear search to O(1) map lookup

## Rationale

Follows AGENTS.md declarative style guidelines:
- **Named helpers**: `validateSchema` has clear single purpose
- **Data-first shapes**: map lookup replaces linear search

## Changes

| Before | After |
|--------|-------|
| Inline validation loop in `NewParquetCodec` | Extracted to `validateSchema` helper |
| `getFieldByName`: 6-line loop with early return | 1-line map lookup |
| `map[string]bool` for duplicate detection | `map[string]ParquetField` serves both purposes |

## Test plan

- [x] All 29 Parquet tests pass unchanged
- [x] No API changes
- [x] No error message changes
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)