### PR TITLE
feat(examples): ✨ add Parquet codec example

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ This keeps Lode's core APIs explicit and predictable.
 | [`blob_upload`](examples/blob_upload) | Raw blob write/read (no codec, default bundle) | `go run ./examples/blob_upload` |
 | [`manifest_driven`](examples/manifest_driven) | Demonstrates manifest-as-commit-signal | `go run ./examples/manifest_driven` |
 | [`stream_write_records`](examples/stream_write_records) | Streaming record writes with iterator | `go run ./examples/stream_write_records` |
+| [`parquet`](examples/parquet) | Parquet codec with schema-typed fields | `go run ./examples/parquet` |
 | [`s3_experimental`](examples/s3_experimental) | S3 adapter with LocalStack/MinIO | `go run ./examples/s3_experimental` |
 
 Each example is self-contained and runnable. See the example source for detailed comments.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -35,6 +35,7 @@ tasks:
       - go run ./examples/blob_upload
       - go run ./examples/manifest_driven
       - go run ./examples/stream_write_records
+      - go run ./examples/parquet
 
   snippets:
     desc: Verify runnable markdown snippets

--- a/examples/parquet/main.go
+++ b/examples/parquet/main.go
@@ -17,7 +17,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/justapithecus/lode/internal/testutil"
 	"github.com/justapithecus/lode/lode"
 )
 
@@ -35,7 +34,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	defer testutil.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 
 	fmt.Printf("Storage root: %s\n\n", tmpDir)
 


### PR DESCRIPTION
## Summary

Adds `examples/parquet/` demonstrating the Parquet codec feature for v0.5.0.

## Demonstrates

- **Schema definition**: `ParquetSchema` with typed `ParquetField` entries
- **Type system**: int64, string, float64, bool, timestamp
- **Nullable fields**: `score` is nil for one record
- **Compression guidance**: Uses `NewNoOpCompressor()` since Parquet handles compression internally
- **Round-trip verification**: Shows type preservation after decode

## Output

```
=== SCHEMA ===
Schema fields:
  - id: int64
  - name: string
  - score: float64 (nullable)
  - active: bool
  - created_at: timestamp

=== WRITE ===
Created snapshot: ...
Row count: 3
Codec: parquet, Compressor: noop

=== READ ===
Records read back (3):
  id=1 name=alice score=95.5 active=true ...
  id=2 name=bob score=<nil> active=true ...
  id=3 name=charlie score=88 active=false ...

Type verification:
  id type: int64 (value: 1)
  score type: float64 (value: 95.5)
  bob's score (nullable): <nil> (nil=true)
```

## Test plan

- [x] `go build ./examples/parquet/` succeeds
- [x] `go run ./examples/parquet/` runs successfully
- [x] Follows existing example conventions (default_layout pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)