### PR TITLE
fix(release): 🚀 fix lint and prepare v0.5.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No changes yet._
+
+---
+
+## [0.5.0] - 2026-02-06
+
 ### Added
 
 - **Parquet Codec**: `NewParquetCodec(schema, opts...)` for columnar storage with schema-explicit encoding
+- **Parquet Example**: `examples/parquet/` demonstrating schema-typed columnar storage
 - **Parquet Types**: `ParquetSchema`, `ParquetField`, and `ParquetType` constants for all primitive types
 - **Parquet Compression**: `WithParquetCompression()` option for Snappy/Gzip internal compression
 - **Parquet Error Sentinels**: `ErrSchemaViolation` and `ErrInvalidFormat` for precise error handling
@@ -234,7 +241,9 @@ Post-v0.3.0 improvements planned:
 
 ---
 
-[Unreleased]: https://github.com/justapithecus/lode/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/justapithecus/lode/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/justapithecus/lode/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/justapithecus/lode/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/justapithecus/lode/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/justapithecus/lode/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/justapithecus/lode/compare/v0.1.0...v0.2.0

--- a/examples/parquet/main.go
+++ b/examples/parquet/main.go
@@ -34,7 +34,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	fmt.Printf("Storage root: %s\n\n", tmpDir)
 


### PR DESCRIPTION
## Summary

Fixes CI failure and prepares for v0.5.0 release.

## Changes

1. **Fix lint error**: `defer func() { _ = os.RemoveAll(tmpDir) }()` to satisfy errcheck
2. **Finalize CHANGELOG for v0.5.0**:
   - Change `[Unreleased]` to `[0.5.0] - 2026-02-06`
   - Add new empty `[Unreleased]` section
   - Add Parquet example to changelog
   - Update version comparison links (add 0.4.1, 0.5.0)

## Test plan

- [x] `task lint` passes
- [x] `task test` passes
- [x] `task examples` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)