### PR TITLE
feat(examples): ✨ add sparse Volume ranges example

### DIFF
--- a/examples/volume_sparse/main.go
+++ b/examples/volume_sparse/main.go
@@ -109,11 +109,14 @@ func run() error {
 
 	// Sector 1 [256, 512) was never committed — reading it must fail.
 	_, err = vol.ReadAt(ctx, snap1.ID, 256, 256)
-	if errors.Is(err, lode.ErrRangeMissing) {
+	switch {
+	case errors.Is(err, lode.ErrRangeMissing):
 		fmt.Printf("ReadAt [256, 512) returned ErrRangeMissing (expected)\n")
 		fmt.Printf("  Sparse volumes explicitly track which ranges are committed.\n")
 		fmt.Printf("  Gaps are detected, not silently zero-filled.\n\n")
-	} else {
+	case err == nil:
+		return fmt.Errorf("expected ErrRangeMissing for gap, but ReadAt succeeded")
+	default:
 		return fmt.Errorf("expected ErrRangeMissing for gap, got: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Adds `examples/volume_sparse/` demonstrating the Volume persistence API
- Covers all four PR5 deliverables from `IMPLEMENTATION_PLAN.md`
- Follows existing example conventions (main/run pattern, temp dir, section headers)

### Sections demonstrated

| Section | Concept |
|---------|---------|
| Setup | `NewVolume` with 1 KB address space (4 x 256-byte sectors) |
| First Commit | Stage two non-contiguous sectors [0,256) and [512,768), commit |
| ErrRangeMissing | Read uncommitted gap [256,512) — explicit gap detection |
| Incremental Commit | Fill the gap, cumulative manifest grows to 3 blocks |
| Resume Pattern | New Volume instance on same store, `Latest()`, stage + commit |
| Full Read | Read all 1024 bytes, verify each sector's fill byte |

## Test plan

- [x] `go run ./examples/volume_sparse/` — runs and prints expected output
- [x] `go build ./...` — compiles clean
- [x] `golangci-lint run ./examples/...` — 0 issues
- [x] `go vet ./...` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)