### PR TITLE
docs(roadmap): 📝 mark Parquet and Volume Phase 6 deliverables complete

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -202,7 +202,7 @@ Explore new adapters or codecs without expanding the public API.
 - [x] No backend-specific conditionals
 - [x] CONTRACT_STORAGE.md compliance verified
 - [x] Zstd compressor added as an additive compression option
-- [ ] Parquet codec implemented
+- [x] Parquet codec implemented
 - [ ] Manifest stats extensions finalized (additive)
 
 ### S3 Adapter
@@ -292,24 +292,24 @@ without blurring Lode's scope boundary.
 
 ### Phase-0 Volume Deliverables
 
-- [ ] Public `Volume` abstraction and constructor shape documented
-- [ ] Volume snapshot manifest model documented (`volume_id`, `total_length`, committed blocks)
-- [ ] Explicit range-read semantics documented (missing ranges are errors, no zero-fill inference)
-- [ ] Filesystem and memory validation examples for sparse/resumable flows
-- [ ] Restart/resume correctness tests for committed blocks
+- [x] Public `Volume` abstraction and constructor shape documented
+- [x] Volume snapshot manifest model documented (`volume_id`, `total_length`, committed blocks)
+- [x] Explicit range-read semantics documented (missing ranges are errors, no zero-fill inference)
+- [x] Filesystem and memory validation examples for sparse/resumable flows
+- [x] Restart/resume correctness tests for committed blocks
 
 ### Dataset Streaming Boundary (Retained)
 
-- [ ] Clarify in docs and API guidance that Dataset streaming is atomic object construction
-- [ ] Preserve guarantee: object is either fully committed in snapshot or absent
-- [ ] Explicitly route sparse/resumable/range-verified workflows to Volume
+- [x] Clarify in docs and API guidance that Dataset streaming is atomic object construction
+- [x] Preserve guarantee: object is either fully committed in snapshot or absent
+- [x] Explicitly route sparse/resumable/range-verified workflows to Volume
 
 ### Phase-0 Exclusions
 
-- [ ] No torrent protocol concepts (pieces, peers, trackers)
-- [ ] No networking, scheduling, or runtime orchestration
-- [ ] No hash policy ownership in Lode core
-- [ ] No deployables/daemons added to Lode
+- [x] No torrent protocol concepts (pieces, peers, trackers)
+- [x] No networking, scheduling, or runtime orchestration
+- [x] No hash policy ownership in Lode core
+- [x] No deployables/daemons added to Lode
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `docs/IMPLEMENTATION_PLAN.md` to check off 13 deliverables that shipped across v0.5.0 (Parquet) and v0.6 PRs (Volume). No code changes.

## Highlights

- Phase 5: mark Parquet codec as implemented (shipped in v0.5.0)
- Phase 6 Volume Deliverables: all 5 items complete (PRs #92–#99)
- Phase 6 Dataset Streaming Boundary: all 3 items documented (PR #98)
- Phase 6 Exclusions: all 4 scope assertions confirmed

## Test plan

- [ ] Verify diff is checkbox-only (no prose or code changes)
- [ ] Confirm remaining open items (manifest stats, Zarr) are still unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)