### PR TITLE
feat(manifest): ✨ add per-file column statistics for codec-agnostic pruning

### DIFF
--- a/docs/contracts/CONTRACT_CORE.md
+++ b/docs/contracts/CONTRACT_CORE.md
@@ -55,6 +55,19 @@ Minimum required fields:
 - min/max timestamp (when data units implement `Timestamped`; omit if not applicable)
 Optional fields:
 - codec name (omit when no codec is configured)
+- per-file statistics (when the codec reports them via `StatisticalCodec`; omit when not available)
+
+### Per-File Statistics
+
+FileRef MAY contain per-file statistics reported by the codec.
+
+- Statistics are codec-agnostic: any codec may report them via the `StatisticalCodec` interface.
+- When a codec reports statistics, they MUST be persisted on the FileRef.
+- When a codec does not report statistics, the stats field MUST be omitted.
+- Statistics values MUST be JSON-serializable.
+- Statistics MUST NOT be inferred; they are reported by the codec from observed data.
+- Per-file statistics include: row count, and per-column min, max, null count, and distinct count.
+- Distinct count is optional; zero means not computed.
 
 ### Checksum Rules
 

--- a/docs/contracts/CONTRACT_PARQUET.md
+++ b/docs/contracts/CONTRACT_PARQUET.md
@@ -240,14 +240,20 @@ The following statistics MAY be extracted and recorded in manifests:
 - `RowCount`: Total rows in the file (from Parquet metadata).
 - `MinTimestamp` / `MaxTimestamp`: When a timestamp column is designated.
 
-### Future: Extended Manifest Stats
+### Per-File Statistics
 
-Future versions MAY add:
-- Column-level min/max statistics.
-- Null counts per column.
-- Byte size per column.
+The Parquet codec implements `StatisticalCodec` and reports per-file statistics
+via `FileStats()` after each `Encode` call:
 
-These extensions are additive and do not affect this contract.
+- `RowCount`: Total rows encoded in the file.
+- Per-column `Min` and `Max` for orderable types: int32, int64, float32, float64, string, timestamp.
+- Per-column `NullCount`: Number of null values for nullable columns.
+- `DistinctCount`: Reserved for future use (reported as 0).
+- Boolean and bytes columns report `NullCount` only (no min/max).
+- Statistics are computed during `Encode` from the Go record values, not from Parquet internal metadata.
+- Min/Max values use the same Go types as the input records. When serialized to
+  JSON, `time.Time` becomes an RFC3339Nano string; consumers must interpret based
+  on schema context.
 
 ---
 

--- a/docs/contracts/CONTRACT_WRITE_API.md
+++ b/docs/contracts/CONTRACT_WRITE_API.md
@@ -33,6 +33,8 @@ It is authoritative for any `Dataset` implementation.
 - Writes MUST NOT mutate existing snapshots or manifests.
 - The manifest MUST include all required fields defined in `CONTRACT_CORE.md`
   (including row/event count and min/max timestamp when applicable).
+- When the codec implements `StatisticalCodec`, per-file statistics MUST be
+  collected after encoding and recorded on the FileRef.
 - When no codec is configured, each write represents a single data unit and
   the row/event count MUST be `1`.
 
@@ -68,6 +70,8 @@ It is authoritative for any `Dataset` implementation.
 - Row/event count MUST equal the total number of records consumed.
 - When a checksum component is configured, the checksum MUST be computed during
   streaming and recorded in the manifest for each file written.
+- When the stream encoder implements `StatisticalStreamEncoder`, per-file
+  statistics MUST be collected after stream finalization and recorded on the FileRef.
 
 ### Timestamp computation
 


### PR DESCRIPTION
## Summary

Adds per-file column statistics to manifest `FileRef`s, enabling external readers to prune files without opening them. The design is codec-agnostic via an optional `StatisticalCodec` interface; the Parquet codec is the first implementation.

## Highlights

- New `FileStats` and `ColumnStats` types on `FileRef` (omitempty for backward compat)
- New `StatisticalCodec` and `StatisticalStreamEncoder` opt-in interfaces
- Parquet codec reports min/max for orderable types (int32, int64, float32, float64, string, timestamp) and null count for all columns
- JSONL and raw blob writes produce no stats (`FileRef.Stats` is nil)
- Write path wired in both `writeDataFile` (batch) and `StreamWriteRecords` (streaming)
- 14 new tests: codec stats, write-path wiring, JSON round-trip, backward compat
- Contracts updated: `CONTRACT_CORE.md`, `CONTRACT_PARQUET.md`, `CONTRACT_WRITE_API.md`

## Test plan

- [ ] All 14 new stats tests pass
- [ ] All existing tests still pass
- [ ] `golangci-lint` clean
- [ ] Examples compile
- [ ] JSONL manifest JSON has no `stats` key; Parquet manifest JSON has `stats` with columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)