### PR TITLE
docs(release): 📝 v0.7.1 changelog, README updates, and test matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.1] - 2026-02-09
+
+### Fixed
+
+- **O(n²) write degradation on remote stores**: `Write()`, `StreamWrite()`, and `StreamWriteRecords()` called `Latest()` on every invocation, scanning all manifests via `store.List` + N×`store.Get`. On remote stores (S3, R2), this caused sequential writes to degrade quadratically. A 40-write burst that should complete in <1s took ~40 minutes. Parent snapshot ID is now cached after each successful write; only the first write (cold start) falls back to `Latest()`. ([#109](https://github.com/pithecene-io/lode/pull/109), closes [#108](https://github.com/pithecene-io/lode/issues/108))
+
+### Added
+
+- **Sequential write benchmarks**: `BenchmarkDataset_SequentialWrites` (wall-clock with simulated latency) and `BenchmarkDataset_SequentialWrites_StoreCallCount` (correctness assertion) guard against parent-resolution regressions
+
+### Upgrade Notes
+
+- No API changes; transparent internal optimization
+- All write paths (`Write`, `StreamWrite`, `StreamWriteRecords`) benefit automatically
+- Safe to upgrade from v0.7.0
+
+---
+
 ## [0.7.0] - 2026-02-07
 
 ### Added
@@ -312,12 +330,13 @@ Post-v0.3.0 improvements planned:
 
 ---
 
-[Unreleased]: https://github.com/justapithecus/lode/compare/v0.7.0...HEAD
-[0.7.0]: https://github.com/justapithecus/lode/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/justapithecus/lode/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/justapithecus/lode/compare/v0.4.1...v0.5.0
-[0.4.1]: https://github.com/justapithecus/lode/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/justapithecus/lode/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/justapithecus/lode/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/justapithecus/lode/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/justapithecus/lode/releases/tag/v0.1.0
+[Unreleased]: https://github.com/pithecene-io/lode/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/pithecene-io/lode/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/pithecene-io/lode/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/pithecene-io/lode/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/pithecene-io/lode/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/pithecene-io/lode/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/pithecene-io/lode/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/pithecene-io/lode/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/pithecene-io/lode/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/pithecene-io/lode/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ For full contract details: [`docs/contracts/`](docs/contracts/)
 
 Common pitfalls when using Lode:
 
-- **Metadata must be non-nil** — Pass `lode.Metadata{}` for empty metadata, not `nil`.
+- **Metadata defaults to empty** — `nil` metadata is coalesced to `Metadata{}`; pass `nil` or `Metadata{}` for empty metadata.
 - **Raw mode expects `[]byte`** — Without a codec, `Write` expects exactly one `[]byte` element.
 - **Single-writer only** — Concurrent writers to the same dataset or volume may corrupt history.
 - **Cleanup is best-effort** — Failed streams may leave partial objects in storage.
@@ -309,7 +309,7 @@ Each example is self-contained and runnable. See the example source for detailed
 
 ## Status
 
-Lode is at **v0.7.0** and under active development.
+Lode is at **v0.7.1** and under active development.
 APIs are stabilizing; some changes are possible before v1.0.
 
 If you are evaluating Lode, focus on:

--- a/docs/contracts/CONTRACT_TEST_MATRIX.md
+++ b/docs/contracts/CONTRACT_TEST_MATRIX.md
@@ -83,6 +83,7 @@ Gaps are tracked with codes indicating category and priority:
 | Creates snapshot | Multiple write tests |
 | nil metadata coalesced | `TestDataset_Write_NilMetadata_CoalescesToEmpty` |
 | Parent snapshot linked | `TestDataset_StreamWrite_ParentSnapshotLinked` |
+| Parent ID cached (O(1) after first write) | `TestDataset_Write_CachesParentSnapshotID` |
 | Raw blob RowCount=1 | `TestDataset_StreamWrite_Success` |
 
 **StreamWrite**: All covered ✅
@@ -95,6 +96,7 @@ Gaps are tracked with codes indicating category and priority:
 | Abort → no manifest | `TestDataset_StreamWrite_Abort_NoManifest` |
 | Close without Commit → abort | `TestDataset_StreamWrite_CloseWithoutCommit_BehavesAsAbort` |
 | Codec configured → error | `TestDataset_StreamWrite_WithCodec_ReturnsError` |
+| Parent ID cached across StreamWrite→Commit | `TestDataset_StreamWrite_CachesParentSnapshotID` |
 | Checksum computed | `TestDataset_StreamWrite_WithChecksum_RecordsChecksum` |
 | Manifest Put error → no manifest + cleanup | `TestStreamWrite_ManifestPutError_NoManifest_CleanupAttempted` |
 | Abort → cleanup attempted | `TestStreamWrite_Abort_NoManifest_CleanupAttempted` |
@@ -113,6 +115,7 @@ Gaps are tracked with codes indicating category and priority:
 | Iterator error → no manifest | `TestDataset_StreamWriteRecords_IteratorError` |
 | RowCount = records consumed | `TestDataset_StreamWriteRecords_Success` |
 | Iterator error → cleanup attempted | `TestStreamWriteRecords_IteratorError_NoManifest_CleanupAttempted` |
+| Parent ID cached across StreamWriteRecords | `TestDataset_StreamWriteRecords_CachesParentSnapshotID` |
 | Manifest Put error → no manifest + cleanup | `TestStreamWriteRecords_ManifestPutError_NoManifest` |
 
 **Timestamp Computation**: All covered ✅


### PR DESCRIPTION
## Summary

Documentation sweep to prep for v0.7.1 patch release. Updates changelog, fixes a stale README gotcha, bumps version references, and adds test traceability for the parent-ID caching fix (#109).

## Highlights

- **CHANGELOG.md**: Add v0.7.1 entry (Fixed + Added sections), update all comparison links from `justapithecus` → `pithecene-io` org
- **README.md**: Fix stale "Metadata must be non-nil" gotcha — nil metadata has been safe since v0.7.0 coalescing; bump status version to v0.7.1
- **CONTRACT_TEST_MATRIX.md**: Add three parent-ID caching test rows (Write, StreamWrite, StreamWriteRecords) for contract traceability

## Test plan

- [ ] CHANGELOG entry follows Keep a Changelog format
- [ ] Comparison links resolve to pithecene-io/lode
- [ ] README gotcha matches v0.7.0 nil coalescing behavior
- [ ] Test matrix rows reference existing test names

🤖 Generated with [Claude Code](https://claude.com/claude-code)