### PR TITLE
refactor(build): 🚚 rename module path from justapithecus to pithecene-io

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,7 +39,7 @@ formatters:
     gofumpt:
       extra-rules: true
     goimports:
-      local-prefixes: github.com/justapithecus/lode
+      local-prefixes: github.com/pithecene-io/lode
 
 linters-settings:
   contextcheck:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.2] - 2026-02-09
+
+### Changed
+
+- **Go module path**: Renamed from `github.com/justapithecus/lode` to `github.com/pithecene-io/lode` across all source, tests, examples, documentation, and tooling configuration
+
+### Upgrade Notes
+
+- **Import path migration**: Update all import paths in your codebase:
+  - `github.com/justapithecus/lode/lode` → `github.com/pithecene-io/lode/lode`
+  - `github.com/justapithecus/lode/lode/s3` → `github.com/pithecene-io/lode/lode/s3`
+- **go.mod**: Update `require` directive to `github.com/pithecene-io/lode`
+- No behavior changes; all APIs, semantics, and contracts are unchanged
+
+---
+
 ## [0.7.1] - 2026-02-09
 
 ### Fixed
@@ -330,7 +346,8 @@ Post-v0.3.0 improvements planned:
 
 ---
 
-[Unreleased]: https://github.com/pithecene-io/lode/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/pithecene-io/lode/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/pithecene-io/lode/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/pithecene-io/lode/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/pithecene-io/lode/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/pithecene-io/lode/compare/v0.5.0...v0.6.0

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -33,7 +33,7 @@ Example:
 <!-- illustrative -->
 ```go
 import (
-    "github.com/justapithecus/lode/lode"
+    "github.com/pithecene-io/lode/lode"
 )
 
 ds, _ := lode.NewDataset(
@@ -612,7 +612,7 @@ import (
     "github.com/aws/aws-sdk-go-v2/config"
     awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 
-    "github.com/justapithecus/lode/lode/s3"
+    "github.com/pithecene-io/lode/lode/s3"
 )
 
 cfg, _ := config.LoadDefaultConfig(ctx)
@@ -634,7 +634,7 @@ import (
     "github.com/aws/aws-sdk-go-v2/credentials"
     awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 
-    "github.com/justapithecus/lode/lode/s3"
+    "github.com/pithecene-io/lode/lode/s3"
 )
 
 cfg, _ := config.LoadDefaultConfig(ctx,

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you know the snapshot ID, you know exactly what data you are reading.
 
 <!-- runnable -->
 ```bash
-go get github.com/justapithecus/lode
+go get github.com/pithecene-io/lode
 ```
 
 ### Write and read a blob
@@ -87,7 +87,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/justapithecus/lode/lode"
+    "github.com/pithecene-io/lode/lode"
 )
 
 func main() {
@@ -309,7 +309,7 @@ Each example is self-contained and runnable. See the example source for detailed
 
 ## Status
 
-Lode is at **v0.7.1** and under active development.
+Lode is at **v0.7.2** and under active development.
 APIs are stabilizing; some changes are possible before v1.0.
 
 If you are evaluating Lode, focus on:

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -231,7 +231,7 @@ import (
     "github.com/aws/aws-sdk-go-v2/config"
     awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 
-    "github.com/justapithecus/lode/lode/s3"
+    "github.com/pithecene-io/lode/lode/s3"
 )
 
 // AWS S3 (use standard AWS SDK config)

--- a/docs/SNIPPET_POLICY.md
+++ b/docs/SNIPPET_POLICY.md
@@ -78,7 +78,7 @@ ds, _ := lode.NewDataset("mydata", lode.NewFSFactory("/data"))
 
 <!-- runnable -->
 ```bash
-go get github.com/justapithecus/lode
+go get github.com/pithecene-io/lode
 ```
 ```
 

--- a/docs/contracts/CONTRACT_TEST_MATRIX.md
+++ b/docs/contracts/CONTRACT_TEST_MATRIX.md
@@ -418,8 +418,8 @@ These gaps will be addressed when the relevant APIs are exposed.
 
 ```
 $ go test ./...
-ok  	github.com/justapithecus/lode/lode
-ok  	github.com/justapithecus/lode/lode/s3
+ok  	github.com/pithecene-io/lode/lode
+ok  	github.com/pithecene-io/lode/lode/s3
 ```
 
 All contracts have test coverage except for deferred gaps and documented residual risk.

--- a/examples/blob_upload/main.go
+++ b/examples/blob_upload/main.go
@@ -21,8 +21,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/justapithecus/lode/internal/testutil"
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/internal/testutil"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/examples/default_layout/main.go
+++ b/examples/default_layout/main.go
@@ -16,8 +16,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/justapithecus/lode/internal/testutil"
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/internal/testutil"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/examples/hive_layout/main.go
+++ b/examples/hive_layout/main.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/justapithecus/lode/internal/testutil"
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/internal/testutil"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/examples/manifest_driven/main.go
+++ b/examples/manifest_driven/main.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/justapithecus/lode/internal/testutil"
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/internal/testutil"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/examples/parquet/main.go
+++ b/examples/parquet/main.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/examples/s3_experimental/main.go
+++ b/examples/s3_experimental/main.go
@@ -22,8 +22,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 
-	"github.com/justapithecus/lode/lode"
-	"github.com/justapithecus/lode/lode/s3"
+	"github.com/pithecene-io/lode/lode"
+	"github.com/pithecene-io/lode/lode/s3"
 )
 
 func main() {

--- a/examples/stream_write_records/main.go
+++ b/examples/stream_write_records/main.go
@@ -16,8 +16,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/justapithecus/lode/internal/testutil"
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/internal/testutil"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/examples/volume_sparse/main.go
+++ b/examples/volume_sparse/main.go
@@ -23,8 +23,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/justapithecus/lode/internal/testutil"
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/internal/testutil"
+	"github.com/pithecene-io/lode/lode"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/justapithecus/lode
+module github.com/pithecene-io/lode
 
 go 1.25.6
 

--- a/lode/adapter_timing_test.go
+++ b/lode/adapter_timing_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/justapithecus/lode/internal/testutil"
+	"github.com/pithecene-io/lode/internal/testutil"
 )
 
 // -----------------------------------------------------------------------------

--- a/lode/s3/integration_test.go
+++ b/lode/s3/integration_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/lode"
 )
 
 // Integration tests for S3-compatible backends.

--- a/lode/s3/store.go
+++ b/lode/s3/store.go
@@ -64,7 +64,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/lode"
 )
 
 // S3 multipart upload constraints.

--- a/lode/s3/store_test.go
+++ b/lode/s3/store_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3api "github.com/aws/aws-sdk-go-v2/service/s3"
 
-	"github.com/justapithecus/lode/lode"
+	"github.com/pithecene-io/lode/lode"
 )
 
 // -----------------------------------------------------------------------------

--- a/lode/store_test.go
+++ b/lode/store_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/justapithecus/lode/internal/testutil"
+	"github.com/pithecene-io/lode/internal/testutil"
 )
 
 // -----------------------------------------------------------------------------

--- a/scripts/verify-snippets.sh
+++ b/scripts/verify-snippets.sh
@@ -84,7 +84,7 @@ package main
 import (
     "context"
     "fmt"
-    _ "github.com/justapithecus/lode/lode"
+    _ "github.com/pithecene-io/lode/lode"
 )
 
 var _ = context.Background
@@ -100,7 +100,7 @@ GOEOF
     (
         cd "$tmpdir"
         go mod init snippet 2>/dev/null
-        go mod edit -replace github.com/justapithecus/lode="$REPO_ROOT" 2>/dev/null
+        go mod edit -replace github.com/pithecene-io/lode="$REPO_ROOT" 2>/dev/null
     ) || true
 
     if (cd "$tmpdir" && go build -o /dev/null ./... 2>/dev/null); then


### PR DESCRIPTION
## Summary

Renames the Go module path from `github.com/justapithecus/lode` to `github.com/pithecene-io/lode` across the entire repository to reflect the GitHub organization rename.

## Highlights

- Update `go.mod` module declaration to `github.com/pithecene-io/lode`
- Update all Go import paths across source, tests, and examples (22 files)
- Update documentation references (README, PUBLIC_API, contracts, implementation plan)
- Update tooling configs (`.golangci.yaml` local-prefixes, `verify-snippets.sh`)
- Add CHANGELOG v0.7.2 entry with import path migration notes
- Bump README version badge to v0.7.2

## Test plan

- [ ] `go build ./...` succeeds with new module path
- [ ] `go test ./...` passes
- [ ] `task lint` passes
- [ ] Examples compile and run
- [ ] `verify-snippets.sh` passes with updated replace directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)