### PR TITLE
refactor(test): ♻️ use b.Context() in benchmarks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Assume it is invalid and stop.
 
 ## Testing conventions
 
-- Use `t.Context()` instead of `context.Background()` in tests
+- Use `t.Context()` / `b.Context()` instead of `context.Background()` in tests and benchmarks
 - Use `errors.Is()` for error comparisons, not `==`
 
 ---

--- a/lode/dataset_bench_test.go
+++ b/lode/dataset_bench_test.go
@@ -68,13 +68,12 @@ func BenchmarkDataset_SequentialWrites(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	ctx := context.Background()
 	data := R(D{"key": "value"})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < writeCount; j++ {
-			if _, err := ds.Write(ctx, data, Metadata{}); err != nil {
+			if _, err := ds.Write(b.Context(), data, Metadata{}); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -93,7 +92,6 @@ func BenchmarkDataset_SequentialWrites_StoreCallCount(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	ctx := context.Background()
 	data := R(D{"key": "value"})
 
 	b.ResetTimer()
@@ -101,14 +99,14 @@ func BenchmarkDataset_SequentialWrites_StoreCallCount(b *testing.B) {
 		fs.Reset()
 
 		// Cold-start write (will call List)
-		if _, err := ds.Write(ctx, data, Metadata{}); err != nil {
+		if _, err := ds.Write(b.Context(), data, Metadata{}); err != nil {
 			b.Fatal(err)
 		}
 		coldListCalls := len(fs.ListCalls())
 
 		// Subsequent writes (should NOT call List)
 		for j := 1; j < 20; j++ {
-			if _, err := ds.Write(ctx, data, Metadata{}); err != nil {
+			if _, err := ds.Write(b.Context(), data, Metadata{}); err != nil {
 				b.Fatal(err)
 			}
 		}


### PR DESCRIPTION
## Summary

- Replace `context.Background()` with `b.Context()` in benchmark functions for consistency with test convention
- Update AGENTS.md testing conventions to document `b.Context()` alongside `t.Context()`

## Test plan

- [x] `go test -bench=BenchmarkDataset_Sequential ./lode/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)