### PR TITLE
feat(build): 📊 add benchstat tooling and statistical benchmark tasks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
         run: task integration
 
       - name: 📊 Benchmarks
-        run: task bench
+        run: task bench:stat
 
       - name: 🐳 Stop S3 Services
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ This installs:
 - Go 1.25.6
 - [Task](https://taskfile.dev/) 3.47.0
 - [golangci-lint](https://golangci-lint.run/) 2.8.0
+- [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
 
 ## Development tasks
 
@@ -25,6 +26,8 @@ This installs:
 | `task examples` | Run all examples |
 | `task snippets` | Verify runnable markdown snippets |
 | `task bench` | Run all benchmarks (start `s3:up` first for S3) |
+| `task bench:stat` | Run benchmarks with `-count=10` + benchstat summary |
+| `task bench:compare` | Compare two benchmark result files via benchstat |
 | `task integration` | Run integration tests (requires `s3:up`) |
 
 ### Integration tests

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -63,3 +63,17 @@ tasks:
     cmds:
       - go test -bench=. -benchmem -run=^$ ./lode/...
       - go test -bench=. -benchmem -run=^$ ./lode/s3/... -integration
+
+  bench:stat:
+    desc: Run benchmarks with -count=10 and pipe through benchstat
+    set: [pipefail]
+    cmds:
+      - go test -bench=. -benchmem -count=10 -run=^$ ./lode/... | tee bench-inmemory.txt
+      - go test -bench=. -benchmem -count=10 -run=^$ ./lode/s3/... -integration | tee bench-s3.txt
+      - benchstat bench-inmemory.txt
+      - benchstat bench-s3.txt
+
+  bench:compare:
+    desc: Compare two benchmark result files with benchstat
+    cmds:
+      - benchstat {{.CLI_ARGS}}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -53,6 +53,35 @@ task s3:down    # stop services
 
 In-memory benchmarks always run. S3 benchmarks require services to be up first.
 
+### Statistical comparison
+
+`task bench:stat` runs all benchmarks with `-count=10` and pipes results through
+[benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) for statistical
+summaries. Raw output is saved to `bench-inmemory.txt` and `bench-s3.txt`.
+
+```bash
+task s3:up          # start LocalStack + MinIO
+task bench:stat     # -count=10, benchstat summary
+task s3:down        # stop services
+```
+
+To compare two runs (e.g. before and after a change):
+
+```bash
+# Save baseline
+mv bench-inmemory.txt baseline-inmemory.txt
+
+# Make changes, re-run
+task bench:stat
+
+# Compare
+task bench:compare -- baseline-inmemory.txt bench-inmemory.txt
+```
+
+> **Note:** benchstat requires multiple samples (`-count=10`) to produce
+> meaningful confidence intervals. Single-sample comparisons will show `~`
+> (no significant difference) for most benchmarks.
+
 ### Manual invocation
 
 ```bash

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,5 @@
 "aqua:go-task/task" = "3.47.0"
 "aqua:golangci/golangci-lint" = "2.8.0"
 go = "1.25.6"
+"go:golang.org/x/perf/cmd/benchstat" = "v0.0.0-20260209182753-b57e4e371b65"
 yamllint = "1.38.0"


### PR DESCRIPTION
## Summary

Add benchstat to the toolchain and introduce Taskfile targets for statistically meaningful benchmark comparison. Nightly upgrades from `task bench` to `task bench:stat` for better signal in CI logs.

## Highlights

- Pin `benchstat` in `mise.toml` toolchain
- Add `bench:stat` target: runs `-count=10`, pipes through benchstat
- Add `bench:compare` target: diff two result files via benchstat
- Nightly workflow calls `bench:stat` instead of `bench`
- Document statistical comparison workflow in `docs/BENCHMARKS.md`

## Test plan

- [ ] `mise install` picks up benchstat
- [ ] `task bench:stat` runs locally (with `s3:up`)
- [ ] `task bench:compare -- file1.txt file2.txt` produces delta report
- [ ] `yamllint -s .` passes
- [ ] Nightly workflow runs `bench:stat` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)