### PR TITLE
feat(core): ⚡️ persistent latest pointer for O(1) resolution

### DIFF
--- a/lode/layout.go
+++ b/lode/layout.go
@@ -23,6 +23,7 @@ type layout interface {
 	manifestPath(dataset DatasetID, segment DatasetSnapshotID) string
 	manifestPathInPartition(dataset DatasetID, segment DatasetSnapshotID, partition string) string
 	dataFilePath(dataset DatasetID, segment DatasetSnapshotID, partition, filename string) string
+	latestPointerPath(dataset DatasetID) string
 
 	// Partitioning (unified with layout)
 	partitioner() partitioner
@@ -122,6 +123,10 @@ func (l *defaultLayout) extractPartitionPath(_ string) string {
 
 func (l *defaultLayout) dataFilePath(dataset DatasetID, segment DatasetSnapshotID, _, filename string) string {
 	return path.Join(datasetsDir, string(dataset), snapshotsDir, string(segment), dataDir, filename)
+}
+
+func (l *defaultLayout) latestPointerPath(dataset DatasetID) string {
+	return path.Join(datasetsDir, string(dataset), "latest")
 }
 
 func (l *defaultLayout) partitioner() partitioner {
@@ -295,6 +300,10 @@ func (l *hiveLayout) dataFilePath(dataset DatasetID, segment DatasetSnapshotID, 
 	return path.Join(datasetsDir, string(dataset), partitionsDir, partition, segmentsDir, string(segment), dataDir, filename)
 }
 
+func (l *hiveLayout) latestPointerPath(dataset DatasetID) string {
+	return path.Join(datasetsDir, string(dataset), "latest")
+}
+
 func (l *hiveLayout) partitioner() partitioner {
 	return l.part
 }
@@ -379,6 +388,10 @@ func (l *flatLayout) extractPartitionPath(_ string) string {
 
 func (l *flatLayout) dataFilePath(dataset DatasetID, segment DatasetSnapshotID, _, filename string) string {
 	return path.Join(string(dataset), string(segment), dataDir, filename)
+}
+
+func (l *flatLayout) latestPointerPath(dataset DatasetID) string {
+	return path.Join(string(dataset), "latest")
 }
 
 func (l *flatLayout) partitioner() partitioner {


### PR DESCRIPTION
## Summary

Replace the in-memory parent snapshot ID cache with a persistent `latest` pointer file that enables O(1) snapshot resolution on cold start. Previously, `Latest()` and `resolveParentID()` required scanning all manifests via `store.List` (O(N)), which took ~30 minutes with ~5,800 manifests on S3/R2.

## Highlights

- Add `latestPointerPath()` to layout interface with implementations for default, hive, and flat layouts
- Dataset: remove mutex + in-memory cache, add `readLatestPointer`/`writeLatestPointer` helpers, rewrite `Latest()` and `resolveParentID()` with scan fallback
- Volume: same pointer pattern for `Latest()` and `Commit()` parent resolution
- Pointer write is best-effort (manifest is the commit signal per CONTRACT_STORAGE.md)
- Backward compatible: pre-pointer datasets fall back to scan, pointer created on next write (zero-migration upgrade path)
- Update 3 existing caching tests → pointer tests, add 8 new pointer tests covering read-after-write, multi-write tracking, backward compat, corrupt pointer recovery, and all-layouts path verification

## Test plan

- [x] `go build ./...` — compiles
- [x] `go test ./lode/...` — all 11 new pointer tests + full existing suite pass
- [x] `go test -bench=. ./lode/...` — benchmarks pass with updated assertions
- [x] Backward compat: pre-pointer datasets fall back to scan, pointer created on next write
- [x] Corrupt pointer: falls back to scan gracefully

Closes #118, closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)