### PR TITLE
docs(meta): 📝 v0.7.3 changelog and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,12 @@ Each example is self-contained and runnable. See the example source for detailed
 
 ## Status
 
-Lode is at **v0.7.2** and under active development.
+Lode is at **v0.7.3** and under active development.
 APIs are stabilizing; some changes are possible before v1.0.
+
+v0.7.3 introduces O(1) snapshot resolution (persistent latest pointer),
+O(log B) volume block lookups, and eliminates all known O(N) hotspots on remote stores.
+No API changes; existing data is compatible without migration.
 
 If you are evaluating Lode, focus on:
 - snapshot semantics (Dataset and Volume)


### PR DESCRIPTION
## Summary

Adds the v0.7.3 changelog entry and updates README status ahead of tagging. Covers all 8 performance fixes from #127 and the pointer-before-manifest safety protocol.

## Highlights

- **CHANGELOG.md**: Full `[0.7.3]` section with Fixed, Added, Upgrade Notes, and References
- **README.md**: Status updated from v0.7.2 → v0.7.3 with performance callout
- **Upgrade Notes**: Explicit "no migration required" — pre-v0.7.3 data self-heals on first write

## Test plan

- [ ] CHANGELOG link references resolve correctly
- [ ] README status section reads accurately
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)