### PR TITLE
refactor(core): ♻️ post-complexity readability pass in volume.go

### DIFF
--- a/lode/volume_test.go
+++ b/lode/volume_test.go
@@ -1498,16 +1498,6 @@ func TestFindCoveringBlocks_BinarySearch(t *testing.T) {
 			length:  10,
 			wantErr: ErrRangeMissing,
 		},
-		{
-			name: "sorted input (blocks sorted at load time)",
-			blocks: []BlockRef{
-				{Offset: 0, Length: 10},
-				{Offset: 10, Length: 10},
-				{Offset: 20, Length: 10},
-			},
-			offset: 0, length: 30,
-			wantN: 3,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Focused cleanup of `volume.go` after PR #130 (complexity bounds). Zero behavior changes — readability, DRY, and AGENTS.md compliance only.

## Highlights

- Replace 10 `fmt.Errorf("literal")` calls with `errors.New` (AGENTS.md rule)
- Extract `ensureBlocksSortedByOffset` helper from `validateVolumeManifest` to deduplicate the check-then-sort closure pattern
- Extract `resolveParent` method from `Commit` to encapsulate the 3-phase parent resolution cascade (cache → pointer → scan)
- Remove duplicate "sorted input" test case in `TestFindCoveringBlocks_BinarySearch` (identical to "all blocks")

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] No public API changes
- [x] No error message text changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)