### PR TITLE
docs(meta): 📝 v0.7.4 changelog and README update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.4] - 2026-02-12
+
+### Added
+
+- **Complexity bounds contract**: `CONTRACT_COMPLEXITY.md` documents the cost of every public method in store calls, memory, and CPU. Operations are classified as hot-path (per-read/write), cold-path (explicit listing), or degraded (backward-compat fallback). Cost that exceeds the documented bound is a bug. ([#129](https://github.com/pithecene-io/lode/pull/129))
+- **Cross-references**: `CONTRACT_WRITE_API.md`, `CONTRACT_READ_API.md`, `CONTRACT_VOLUME.md`, and `CONTRACT_STORAGE.md` now link to `CONTRACT_COMPLEXITY.md` for cost definitions. ([#129](https://github.com/pithecene-io/lode/pull/129))
+
+### Fixed
+
+- **CX-1: Per-read sort check in `findCoveringBlocks`**: Blocks are now sorted once at load time in `validateVolumeManifest` instead of checked on every read. ([#130](https://github.com/pithecene-io/lode/pull/130))
+- **CX-3: Double deserialization in `ListPartitions`**: Reduced from 2 Gets per manifest to 1 Get (single-pass extraction). ([#130](https://github.com/pithecene-io/lode/pull/130))
+- **CX-6: Redundant sort checks in `Volume.Snapshots`**: Eliminated by the same load-time sort fix as CX-1. ([#130](https://github.com/pithecene-io/lode/pull/130))
+- **CX-7: `fsStore.List` used `filepath.Walk`**: Replaced with `filepath.WalkDir` to avoid per-entry `os.Stat` calls. ([#130](https://github.com/pithecene-io/lode/pull/130))
+
+### Changed
+
+- **`fmt.Errorf` → `errors.New`**: 10 instances in `volume.go` where no formatting verbs were used, per AGENTS.md code style rules. ([#131](https://github.com/pithecene-io/lode/pull/131))
+- **Extracted `resolveParent` method**: Parent resolution cascade (cache → pointer → scan) moved from inline in `Commit` to a dedicated method for readability. ([#131](https://github.com/pithecene-io/lode/pull/131))
+- **Extracted `ensureBlocksSortedByOffset` helper**: Deduplicated the check-then-sort pattern in `validateVolumeManifest`. ([#131](https://github.com/pithecene-io/lode/pull/131))
+
+### Upgrade Notes
+
+- No API changes; all improvements are internal
+- No migration required; existing data is compatible without modification
+- Safe to upgrade from v0.7.3
+
+### References
+
+- [docs/contracts/CONTRACT_COMPLEXITY.md](docs/contracts/CONTRACT_COMPLEXITY.md) — Complexity bounds contract
+- [docs/contracts/CONTRACT_TEST_MATRIX.md](docs/contracts/CONTRACT_TEST_MATRIX.md) — Contract-to-test traceability
+
+---
+
 ## [0.7.3] - 2026-02-12
 
 ### Fixed
@@ -380,7 +413,8 @@ Post-v0.3.0 improvements planned:
 
 ---
 
-[Unreleased]: https://github.com/pithecene-io/lode/compare/v0.7.3...HEAD
+[Unreleased]: https://github.com/pithecene-io/lode/compare/v0.7.4...HEAD
+[0.7.4]: https://github.com/pithecene-io/lode/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/pithecene-io/lode/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/pithecene-io/lode/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/pithecene-io/lode/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -309,12 +309,12 @@ Each example is self-contained and runnable. See the example source for detailed
 
 ## Status
 
-Lode is at **v0.7.3** and under active development.
+Lode is at **v0.7.4** and under active development.
 APIs are stabilizing; some changes are possible before v1.0.
 
-v0.7.3 introduces O(1) snapshot resolution (persistent latest pointer),
-O(log B) volume block lookups, and eliminates all known O(N) hotspots on remote stores.
-No API changes; existing data is compatible without migration.
+v0.7.4 adds a complexity bounds contract documenting the cost of every public
+method, resolves all known complexity violations, and improves internal code
+quality. No API changes; existing data is compatible without migration.
 
 If you are evaluating Lode, focus on:
 - snapshot semantics (Dataset and Volume)


### PR DESCRIPTION
## Summary

Add v0.7.4 changelog entry and update README status section. Covers PRs #129 (complexity contract), #130 (violation fixes), and #131 (readability pass).

## Highlights

- CHANGELOG: v0.7.4 entry with Added (contract, cross-refs), Fixed (CX-1/3/6/7), Changed (readability)
- README: Status section updated from v0.7.3 → v0.7.4
- Comparison links updated at bottom of CHANGELOG

## Test plan

- [x] No code changes — documentation only
- [x] CHANGELOG follows Keep a Changelog format
- [x] README status text matches v0.7.4 scope
- [ ] Merge after #131 lands on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)