### PR TITLE
docs(dogfood): 📝 update v1 readiness with dogfooding evidence and blob write safety

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -390,6 +390,7 @@ Common errors when using streaming APIs:
 - Layouts that do not model datasets (e.g., flat) return `ErrDatasetsNotModeled`.
 - `ReaderAt` may return an `io.ReaderAt` that also implements `io.Closer`; close it when done.
 - Checksums are computed and recorded in manifests only when configured.
+- Concurrent `Write`/`StreamWrite` calls to the same dataset are safe only with a CAS-capable store (`ConditionalWriter`). Without CAS, serialize writes externally. See `CONTRACT_WRITE_API.md` §Concurrent Blob Write Safety.
 - `StreamWrite` is only valid when no codec is configured; otherwise it returns an error.
 - `StreamWriteRecords` requires a streaming-capable codec; otherwise it returns an error.
 - `StreamWriteRecords` does not support partitioning (single-pass streaming cannot partition).


### PR DESCRIPTION
## Summary

Incorporate dogfooding findings from Quarry integration into V1_READINESS.md, add blob file completeness as a v1.0 blocker criterion, and document concurrent blob write safety in the write API contract.

## Highlights

- Fill in Quarry dogfooding registry with validated evidence (Dataset writes, error sentinels, S3 backend verification, data correctness observations)
- Add §9 Blob File Completeness as new v1.0 gate criterion (blocker per dogfood report)
- Document concurrent blob write safety in CONTRACT_WRITE_API.md (serialization point is pointer update, not data write)
- Add concurrent write gotcha to PUBLIC_API.md
- Update §7 Known Limitations to reflect CAS optimistic concurrency (#135)
- Disambiguate "CAS" terminology in out-of-scope section

## Test plan

- [x] Snippet verification passes
- [x] No code changes — documentation only
- [ ] Review evidence summaries for privacy compliance (no codename details leaked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)