### PR TITLE
ci(race): 👷 add race detection to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,19 @@ jobs:
       - name: 🧪 Test
         run: task test
 
+  race:
+    name: 🏁 Race Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup
+        uses: jdx/mise-action@v2
+
+      - name: 🏁 Race Tests
+        run: task test:race
+
   build:
     name: 🏗️ Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add `-race` detection as a separate parallel job in the CI workflow. Race testing was previously only in `nightly.yml`; now every PR exercises the race detector.

## Highlights
- New `race` job in `.github/workflows/ci.yml` running `task test:race`
- Runs in parallel with existing jobs (lint, test, build, examples, snippets)
- Mirrors the nightly.yml race job structure

## Test plan
- [ ] CI workflow YAML is valid
- [ ] Race job runs in parallel with other CI jobs
- [ ] No impact on existing CI job timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)