### PR TITLE
refactor(s3): ♻️ fix context.Background() violations in tests

### DIFF
--- a/lode/s3/bench_integration_test.go
+++ b/lode/s3/bench_integration_test.go
@@ -40,7 +40,7 @@ func setupBenchBucket(b *testing.B, newClient func(context.Context) (*s3.Client,
 	}
 
 	b.Cleanup(func() {
-		cleanupCtx := context.Background()
+		cleanupCtx := b.Context()
 		out, _ := client.ListObjectsV2(cleanupCtx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
 		for _, obj := range out.Contents {
 			_, _ = client.DeleteObject(cleanupCtx, &s3.DeleteObjectInput{

--- a/lode/s3/integration_test.go
+++ b/lode/s3/integration_test.go
@@ -100,7 +100,7 @@ func setupTestBucket(t *testing.T, backend s3Backend) *Store {
 	}
 
 	t.Cleanup(func() {
-		cleanupCtx := context.Background()
+		cleanupCtx := t.Context()
 		out, _ := client.ListObjectsV2(cleanupCtx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
 		for _, obj := range out.Contents {
 			_, _ = client.DeleteObject(cleanupCtx, &s3.DeleteObjectInput{


### PR DESCRIPTION
## Summary
Replace `context.Background()` with `t.Context()`/`b.Context()` in S3 integration test cleanup functions. The production cleanup context in `s3/store.go` is intentionally independent per CONTRACT_ERRORS.md and is not changed.

## Highlights
- `lode/s3/integration_test.go`: `context.Background()` → `t.Context()` in `setupTestBucket` cleanup
- `lode/s3/bench_integration_test.go`: `context.Background()` → `b.Context()` in `setupBenchBucket` cleanup

## Test plan
- [ ] `go vet ./lode/s3/...` passes
- [ ] `go build ./lode/s3/...` compiles cleanly
- [ ] Existing integration tests unaffected (cleanup uses test context lifecycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)