### PR TITLE
docs(release): 📝 v0.8.0 documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CAS optimistic concurrency**: `ConditionalWriter` interface and `CompareAndSwap` method on FS, Memory, and S3 stores. Dataset and Volume commit paths use CAS when available, falling back to Delete+Put for single-writer stores. `ErrSnapshotConflict` sentinel for conflict detection and retry. ([#134](https://github.com/pithecene-io/lode/pull/134), [#135](https://github.com/pithecene-io/lode/pull/135))
+- **Optimistic concurrency example**: `examples/optimistic_concurrency/` demonstrates CAS conflict detection and retry pattern. ([#135](https://github.com/pithecene-io/lode/pull/135))
+- **Vector artifact pipeline example**: `examples/vector_artifacts/` demonstrates embeddings, indices, and active pointers. ([#138](https://github.com/pithecene-io/lode/pull/138))
+- **AI governance**: `CLAUDE.md` repository constitution and `ai/skills/` repo-local skill definitions. ([#136](https://github.com/pithecene-io/lode/pull/136))
+- **Race detection in CI**: `-race` testing added as a parallel CI job. ([#141](https://github.com/pithecene-io/lode/pull/141))
+- **Test hardening**: Store coverage (Exists, List, path safety), sentinel error messages, and Parquet type conversion. ([#145](https://github.com/pithecene-io/lode/pull/145), [#146](https://github.com/pithecene-io/lode/pull/146))
+
+### Changed
+
+- **Table-driven manifest validation**: `validateVolumeManifest` refactored from sequential checks to validation table. ([#143](https://github.com/pithecene-io/lode/pull/143))
+- **StreamWriteRecords cleanup helper**: Deduplicated 4 cleanup sequences into `cleanupStreamWrite()`. ([#144](https://github.com/pithecene-io/lode/pull/144))
+- **S3 test context**: Replaced `context.Background()` with `t.Context()`/`b.Context()` in S3 integration test cleanup. ([#142](https://github.com/pithecene-io/lode/pull/142))
+
+### Upgrade Notes
+
+- **CAS is always-on**: When the store implements `ConditionalWriter`, CAS is used automatically. No configuration required.
+- **Retry on conflict**: Callers that write concurrently should handle `ErrSnapshotConflict` by re-reading `Latest()`, merging state, and re-committing.
+- **No migration required**: Existing data and stores work without modification. Stores without `ConditionalWriter` retain the existing Delete+Put single-writer path.
+
 ---
 
 ## [0.7.4] - 2026-02-12

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ This keeps Lode's core APIs explicit and predictable.
 | [`stream_write_records`](examples/stream_write_records) | Streaming record writes with iterator | `go run ./examples/stream_write_records` |
 | [`parquet`](examples/parquet) | Parquet codec with schema-typed fields | `go run ./examples/parquet` |
 | [`volume_sparse`](examples/volume_sparse) | Sparse Volume: stage, commit, read with gaps | `go run ./examples/volume_sparse` |
+| [`vector_artifacts`](examples/vector_artifacts) | Vector artifact pipeline: embeddings, indices, pointers | `go run ./examples/vector_artifacts` |
 | [`optimistic_concurrency`](examples/optimistic_concurrency) | CAS conflict detection and retry pattern | `go run ./examples/optimistic_concurrency` |
 | [`s3_experimental`](examples/s3_experimental) | S3 adapter with LocalStack/MinIO | `go run ./examples/s3_experimental` |
 
@@ -310,12 +311,12 @@ Each example is self-contained and runnable. See the example source for detailed
 
 ## Status
 
-Lode is at **v0.7.4** and under active development.
+Lode is at **v0.8.0** and under active development.
 APIs are stabilizing; some changes are possible before v1.0.
 
-v0.7.4 adds a complexity bounds contract documenting the cost of every public
-method, resolves all known complexity violations, and improves internal code
-quality. No API changes; existing data is compatible without migration.
+v0.8.0 adds CAS optimistic concurrency for safe concurrent writes without
+external coordination, plus quality hardening across code, tests, CI, and docs.
+Built-in FS, Memory, and S3 adapters all support CAS. No migration required.
 
 If you are evaluating Lode, focus on:
 - snapshot semantics (Dataset and Volume)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -38,6 +38,8 @@ tasks:
       - go run ./examples/stream_write_records
       - go run ./examples/parquet
       - go run ./examples/optimistic_concurrency
+      - go run ./examples/volume_sparse
+      - go run ./examples/vector_artifacts
 
   snippets:
     desc: Verify runnable markdown snippets

--- a/docs/SNIPPET_POLICY.md
+++ b/docs/SNIPPET_POLICY.md
@@ -123,10 +123,15 @@ If no annotation is present, the snippet is assumed **illustrative** by default.
 | 152-163 | go | Illustrative | Timestamped implementation example |
 | 254-262 | go | Illustrative | Bootstrap helper pattern |
 | 341-346 | go | Illustrative | errors.Is usage pattern |
-| 392-407 | go | Illustrative | AWS S3 client setup |
-| 412-434 | go | Illustrative | LocalStack client setup |
-| 438-451 | go | Illustrative | MinIO client setup |
-| 455-467 | go | Illustrative | Cloudflare R2 client setup |
+| 392-407 | go | Illustrative | AWS S3 client setup (Storage Prerequisites) |
+| 412-434 | go | Illustrative | LocalStack client setup (Storage Prerequisites) |
+| 438-451 | go | Illustrative | MinIO client setup (Storage Prerequisites) |
+| 455-467 | go | Illustrative | Cloudflare R2 client setup (Storage Prerequisites) |
+| 576-581 | go | Illustrative | errors.Is sentinel check pattern |
+| 634-649 | go | Illustrative | AWS S3 client setup (S3 Adapter) |
+| 654-676 | go | Illustrative | LocalStack client setup (S3 Adapter) |
+| 681-694 | go | Illustrative | MinIO client setup (S3 Adapter) |
+| 699-711 | go | Illustrative | Cloudflare R2 client setup (S3 Adapter) |
 
 ### examples/blob_upload/README.md
 


### PR DESCRIPTION
## Summary
Documentation preparation for v0.8.0 release: README updates for CAS capability, CHANGELOG Unreleased section, SNIPPET_POLICY inventory completion, and Taskfile examples task.

## Highlights
- README: add `vector_artifacts` to examples table, update Status section for v0.8.0/CAS
- CHANGELOG: populate Unreleased with CAS headline feature + all prep PRs (#134-#146)
- SNIPPET_POLICY: extend PUBLIC_API.md inventory from line 467 to end of file (5 new entries)
- Taskfile: add `volume_sparse` and `vector_artifacts` to `examples` task

## Test plan
- [ ] `task examples` runs all examples including new entries
- [ ] README examples table is complete and accurate
- [ ] CHANGELOG Unreleased section covers all post-v0.7.4 changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)