### PR TITLE
fix(s3): 🐛 revert cleanup context to context.Background()

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,12 +311,12 @@ Each example is self-contained and runnable. See the example source for detailed
 
 ## Status
 
-Lode is at **v0.8.0** and under active development.
+Lode is at **v0.7.4** and under active development.
 APIs are stabilizing; some changes are possible before v1.0.
 
-v0.8.0 adds CAS optimistic concurrency for safe concurrent writes without
-external coordination, plus quality hardening across code, tests, CI, and docs.
-Built-in FS, Memory, and S3 adapters all support CAS. No migration required.
+v0.7.4 adds a complexity bounds contract documenting the cost of every public
+method, resolves all known complexity violations, and improves internal code
+quality. CAS optimistic concurrency is on main and will ship in v0.8.0.
 
 If you are evaluating Lode, focus on:
 - snapshot semantics (Dataset and Volume)

--- a/lode/s3/bench_integration_test.go
+++ b/lode/s3/bench_integration_test.go
@@ -40,7 +40,7 @@ func setupBenchBucket(b *testing.B, newClient func(context.Context) (*s3.Client,
 	}
 
 	b.Cleanup(func() {
-		cleanupCtx := b.Context()
+		cleanupCtx := context.Background()
 		out, _ := client.ListObjectsV2(cleanupCtx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
 		for _, obj := range out.Contents {
 			_, _ = client.DeleteObject(cleanupCtx, &s3.DeleteObjectInput{

--- a/lode/s3/integration_test.go
+++ b/lode/s3/integration_test.go
@@ -100,7 +100,7 @@ func setupTestBucket(t *testing.T, backend s3Backend) *Store {
 	}
 
 	t.Cleanup(func() {
-		cleanupCtx := t.Context()
+		cleanupCtx := context.Background()
 		out, _ := client.ListObjectsV2(cleanupCtx, &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
 		for _, obj := range out.Contents {
 			_, _ = client.DeleteObject(cleanupCtx, &s3.DeleteObjectInput{


### PR DESCRIPTION
## Summary
Revert PR #142's `context.Background()` → `t.Context()`/`b.Context()` change in S3 test cleanup functions. `t.Context()` is canceled before `t.Cleanup` runs, so cleanup calls would execute with a dead context and silently fail to delete test buckets/objects.

Also revert README version from v0.8.0 back to v0.7.4 — the tag doesn't exist yet.

## Highlights
- `lode/s3/integration_test.go:103`: `t.Context()` → `context.Background()` (revert)
- `lode/s3/bench_integration_test.go:43`: `b.Context()` → `context.Background()` (revert)
- `README.md`: v0.8.0 → v0.7.4 (tag doesn't exist yet)

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go test ./lode/... -count=1 -short` passes
- [ ] Integration test cleanup uses independent context (won't silently fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)