### PR TITLE
fix(docs): 🩹 post-release safety and readiness cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ What Lode commits to:
 | **Immutable snapshots** | Once written, data files and manifests never change |
 | **Atomic commits** | Manifest presence is the commit signal; no partial visibility |
 | **Explicit metadata** | Every snapshot has caller-supplied metadata (never inferred) |
-| **Safe writes** | Overwrites are prevented; atomic on all built-in adapters. Large uploads (>5GB) use conditional multipart on S3 ([details](PUBLIC_API.md#large-upload-guarantees)). |
+| **Safe writes** | Overwrites are prevented; atomic for standard writes on all built-in adapters. Large uploads (>5GB) are atomic when the backend supports conditional multipart completion, best-effort otherwise ([details](PUBLIC_API.md#large-upload-guarantees)). |
 | **Backend-agnostic** | Same semantics on filesystem, memory, or S3 |
 
 What Lode explicitly does NOT provide:

--- a/docs/V1_READINESS.md
+++ b/docs/V1_READINESS.md
@@ -223,9 +223,9 @@ as `(private)` instead of by number.
 
 - [ ] Concurrency model documented in README + PUBLIC_API.md + contracts (single-writer when store lacks `ConditionalWriter`; CAS-based optimistic concurrency when available)
 
-> **Evidence:** _not yet recorded_
-> Date: — | Observer: — | Project: —
-> Summary: CAS optimistic concurrency shipped in v0.8.0 (#135). Contracts, PUBLIC_API.md, and README document `ConditionalWriter`, `ErrSnapshotConflict`, and the adapter CAS capability matrix.
+> **Evidence:** CAS optimistic concurrency shipped in v0.8.0 (#135). Contracts, PUBLIC_API.md, and README document `ConditionalWriter`, `ErrSnapshotConflict`, and the adapter CAS capability matrix. PR #156 added the adapter CAS capability table to PUBLIC_API.md.
+> Date: 2026-02-25 | Observer: @pithecene-io | Project: lode
+> Summary: Concurrency model fully documented across README, PUBLIC_API.md, CONTRACT_WRITE_API.md, and CONTRACT_VOLUME.md. Adapter CAS capability matrix in PUBLIC_API.md.
 > Issue: #135
 
 - [ ] Context cancellation cleanup nondeterminism documented as best-effort, no correctness impact

--- a/lode/dataset_test.go
+++ b/lode/dataset_test.go
@@ -30,7 +30,7 @@ func TestNewDataset_RawBlobWithPartitioner_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for raw blob mode with partitioner, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "raw blob mode") {
 		t.Errorf("expected error message about raw blob mode, got: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestNewHiveLayout_ZeroKeys_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for zero keys, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "at least one partition key") {
 		t.Errorf("expected 'at least one partition key' in error, got: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestWithHiveLayout_ZeroKeys_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for zero keys, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "at least one partition key") {
 		t.Errorf("expected 'at least one partition key' in error, got: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestNewDataset_NilLayout_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil layout, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "layout must not be nil") {
 		t.Errorf("expected 'layout must not be nil' error, got: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestNewDataset_NilCompressor_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil compressor, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "compressor must not be nil") {
 		t.Errorf("expected 'compressor must not be nil' error, got: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestNewDatasetReader_NilFactory_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil factory, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "store factory is required") {
 		t.Errorf("expected 'store factory is required' error, got: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestNewDatasetReader_FactoryReturnsNil_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for factory returning nil, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "returned nil store") {
 		t.Errorf("expected 'returned nil store' error, got: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestNewDatasetReader_NilLayout_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil layout, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "layout must not be nil") {
 		t.Errorf("expected 'layout must not be nil' error, got: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestDataset_Read_CodecMismatch_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for codec mismatch, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "codec mismatch") {
 		t.Errorf("expected 'codec mismatch' error, got: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestDataset_Read_CompressorMismatch_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for compressor mismatch, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "compressor mismatch") {
 		t.Errorf("expected 'compressor mismatch' error, got: %v", err)
 	}
@@ -816,7 +816,7 @@ func TestDataset_RawBlobWrite_MultipleElements_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for multiple elements in raw blob mode, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "exactly one data element") {
 		t.Errorf("expected 'exactly one data element' error, got: %v", err)
 	}
@@ -833,7 +833,7 @@ func TestDataset_RawBlobWrite_WrongType_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for wrong type in raw blob mode, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "requires []byte") {
 		t.Errorf("expected '[]byte' error, got: %v", err)
 	}
@@ -1445,7 +1445,7 @@ func TestDataset_StreamWriteRecords_NoCodec_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for no codec, got nil")
 	}
-	// TODO: convert to errors.Is() when sentinel is introduced
+	// TODO: convert to errors.Is() when a sentinel is introduced for this validation error (plain errors.New today)
 	if !strings.Contains(err.Error(), "requires a codec") {
 		t.Errorf("expected 'requires a codec' error, got: %v", err)
 	}


### PR DESCRIPTION
## Summary

Align safety guarantee language across README, PUBLIC_API.md, and CONTRACT_STORAGE.md. Fill in stale V1 readiness evidence. Improve string-match test TODO rationale.

## Highlights

- **README safety guarantee**: Changed from "atomic on all built-in adapters" to explicitly state standard writes are atomic, large multipart uploads are backend-dependent (matching CONTRACT_STORAGE §Put Upload Paths)
- **V1_READINESS criterion 7.1**: Filled in CAS concurrency documentation evidence — date, observer, issue reference, and summary now populated (was `_not yet recorded_` despite being shipped in v0.8.0)
- **Test TODOs**: Enhanced 13 TODO comments in dataset_test.go with rationale: "plain errors.New today" so future readers understand why sentinels don't exist yet

## What was already addressed (by PR #157)

Items 2 (V1 readiness dates), 3 (contract future-language), and 4 (benchmark isolation) from the cleanup list were already resolved in the audit sweep.

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — all pass
- [x] `task test:race` — no races
- [x] `task examples` — all 10 examples pass
- [x] `task snippets` — all valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)