### PR TITLE
fix(stewardship): 🩹 correct horizon from generational to perennial

### DIFF
--- a/.grove.yaml
+++ b/.grove.yaml
@@ -3,7 +3,7 @@ grove:
     Structured persistence framework for object storage,
     bringing snapshots, metadata, and safe write semantics
     without running a database.
-  horizon: "generational"
+  horizon: "perennial"
   role: "library"
   phase: "consolidating"
   steward: "Andrew"


### PR DESCRIPTION
## Summary

Lode is a persistence library intended to persist and evolve across years, but not designed to span beyond one steward's active tenure. Perennial is the correct horizon.

## Test plan

- [ ] `.grove.yaml` field value is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)