### PR TITLE
chore(ai): 🙈 gitignore bonsai output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ bench-*.txt
 /stream_write_records
 /vector_artifacts
 /volume_sparse
+
+# Bonsai check output (ephemeral)
+ai/out/


### PR DESCRIPTION
## Summary

Add `ai/out/` to `.gitignore` to exclude ephemeral bonsai check outputs (`ai-check.json`, `patch-plan.json`) from version control.

## Test plan

- [ ] Verify `ai/out/` no longer appears in `git status`
- [ ] Confirm existing tracked files are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)